### PR TITLE
fix: loot table conditions, creative drops, stalagmites and falling blocks

### DIFF
--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -711,7 +711,9 @@ static BLOCKS_ACACIA_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ACACIA_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -941,14 +943,28 @@ static BLOCKS_ACACIA_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_ACACIA_SIGN: LootTable = LootTable {
     pools: BLOCKS_ACACIA_SIGN_POOLS,
 };
-static BLOCKS_ACACIA_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:acacia_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_ACACIA_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:acacia_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:acacia_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_ACACIA_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -1139,14 +1155,28 @@ static BLOCKS_ANDESITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_ANDESITE: LootTable = LootTable {
     pools: BLOCKS_ANDESITE_POOLS,
 };
-static BLOCKS_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:andesite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:andesite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:andesite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_ANDESITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANDESITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -1397,7 +1427,9 @@ static BLOCKS_BAMBOO_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BAMBOO_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -1482,14 +1514,28 @@ static BLOCKS_BAMBOO_MOSAIC_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BAMBOO_MOSAIC: LootTable = LootTable {
     pools: BLOCKS_BAMBOO_MOSAIC_POOLS,
 };
-static BLOCKS_BAMBOO_MOSAIC_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:bamboo_mosaic_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BAMBOO_MOSAIC_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:bamboo_mosaic_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:bamboo_mosaic_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BAMBOO_MOSAIC_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_MOSAIC_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -1608,14 +1654,28 @@ static BLOCKS_BAMBOO_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BAMBOO_SIGN: LootTable = LootTable {
     pools: BLOCKS_BAMBOO_SIGN_POOLS,
 };
-static BLOCKS_BAMBOO_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:bamboo_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BAMBOO_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:bamboo_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:bamboo_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BAMBOO_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -1768,7 +1828,9 @@ static BLOCKS_BEETROOTS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -1776,7 +1838,9 @@ static BLOCKS_BEETROOTS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        }),
         bonus_formula: None,
     },
 ];
@@ -1804,7 +1868,9 @@ static BLOCKS_BEETROOTS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        },
     },
 ];
 pub static BLOCKS_BEETROOTS: LootTable = LootTable {
@@ -1887,7 +1953,9 @@ static BLOCKS_BIRCH_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BIRCH_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -2117,14 +2185,28 @@ static BLOCKS_BIRCH_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BIRCH_SIGN: LootTable = LootTable {
     pools: BLOCKS_BIRCH_SIGN_POOLS,
 };
-static BLOCKS_BIRCH_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:birch_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BIRCH_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:birch_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:birch_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BIRCH_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -2212,7 +2294,9 @@ static BLOCKS_BLACK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BLACK_BED_POOLS: &[LootPool] = &[LootPool {
@@ -2225,14 +2309,69 @@ static BLOCKS_BLACK_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BLACK_BED: LootTable = LootTable {
     pools: BLOCKS_BLACK_BED_POOLS,
 };
-static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:black_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:black_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:black_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:black_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:black_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BLACK_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -2441,14 +2580,28 @@ static BLOCKS_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BLACKSTONE: LootTable = LootTable {
     pools: BLOCKS_BLACKSTONE_POOLS,
 };
-static BLOCKS_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:blackstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:blackstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:blackstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BLACKSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACKSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -2536,7 +2689,9 @@ static BLOCKS_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -2549,14 +2704,69 @@ static BLOCKS_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BLUE_BED: LootTable = LootTable {
     pools: BLOCKS_BLUE_BED_POOLS,
 };
-static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:blue_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:blue_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:blue_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:blue_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:blue_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BLUE_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -2914,14 +3124,28 @@ static BLOCKS_BREWING_STAND_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BREWING_STAND: LootTable = LootTable {
     pools: BLOCKS_BREWING_STAND_POOLS,
 };
-static BLOCKS_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -3009,7 +3233,9 @@ static BLOCKS_BROWN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BROWN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -3022,14 +3248,69 @@ static BLOCKS_BROWN_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_BROWN_BED: LootTable = LootTable {
     pools: BLOCKS_BROWN_BED_POOLS,
 };
-static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:brown_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:brown_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:brown_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:brown_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:brown_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_BROWN_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -3462,14 +3743,69 @@ static BLOCKS_CAMPFIRE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CAMPFIRE: LootTable = LootTable {
     pools: BLOCKS_CAMPFIRE_POOLS,
 };
-static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -3530,7 +3866,9 @@ static BLOCKS_CARROTS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_CARROTS: LootTable = LootTable {
@@ -3603,7 +3941,9 @@ static BLOCKS_CAVE_VINES_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("berries", "true")],
+    },
 }];
 pub static BLOCKS_CAVE_VINES: LootTable = LootTable {
     pools: BLOCKS_CAVE_VINES_POOLS,
@@ -3621,7 +3961,9 @@ static BLOCKS_CAVE_VINES_PLANT_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("berries", "true")],
+    },
 }];
 pub static BLOCKS_CAVE_VINES_PLANT: LootTable = LootTable {
     pools: BLOCKS_CAVE_VINES_PLANT_POOLS,
@@ -3649,7 +3991,9 @@ static BLOCKS_CHERRY_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CHERRY_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -3879,14 +4223,28 @@ static BLOCKS_CHERRY_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CHERRY_SIGN: LootTable = LootTable {
     pools: BLOCKS_CHERRY_SIGN_POOLS,
 };
-static BLOCKS_CHERRY_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cherry_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CHERRY_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cherry_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cherry_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CHERRY_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4293,14 +4651,28 @@ static BLOCKS_CINNABAR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CINNABAR: LootTable = LootTable {
     pools: BLOCKS_CINNABAR_POOLS,
 };
-static BLOCKS_CINNABAR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cinnabar_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CINNABAR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cinnabar_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cinnabar_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CINNABAR_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4365,14 +4737,28 @@ static BLOCKS_CINNABAR_BRICKS_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CINNABAR_BRICKS: LootTable = LootTable {
     pools: BLOCKS_CINNABAR_BRICKS_POOLS,
 };
-static BLOCKS_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cinnabar_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cinnabar_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cinnabar_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CINNABAR_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4547,14 +4933,28 @@ static BLOCKS_COBBLED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_COBBLED_DEEPSLATE: LootTable = LootTable {
     pools: BLOCKS_COBBLED_DEEPSLATE_POOLS,
 };
-static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cobbled_deepslate_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cobbled_deepslate_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cobbled_deepslate_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLED_DEEPSLATE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4619,14 +5019,28 @@ static BLOCKS_COBBLESTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_COBBLESTONE: LootTable = LootTable {
     pools: BLOCKS_COBBLESTONE_POOLS,
 };
-static BLOCKS_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cobblestone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cobblestone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cobblestone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_COBBLESTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLESTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4704,14 +5118,28 @@ static BLOCKS_COBWEB_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_COBWEB: LootTable = LootTable {
     pools: BLOCKS_COBWEB_POOLS,
 };
-static BLOCKS_COCOA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cocoa_beans",
-    weight: 1i32,
-    min_count: 3i32,
-    max_count: 3i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_COCOA_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cocoa_beans",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "2")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cocoa_beans",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("age", "2")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_COCOA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COCOA_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -4769,7 +5197,9 @@ static BLOCKS_COMPOSTER_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("level", "8")],
+        },
     },
 ];
 pub static BLOCKS_COMPOSTER: LootTable = LootTable {
@@ -4888,7 +5318,9 @@ static BLOCKS_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -5232,7 +5664,9 @@ static BLOCKS_CRIMSON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CRIMSON_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -5456,14 +5890,28 @@ static BLOCKS_CRIMSON_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CRIMSON_SIGN: LootTable = LootTable {
     pools: BLOCKS_CRIMSON_SIGN_POOLS,
 };
-static BLOCKS_CRIMSON_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:crimson_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CRIMSON_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:crimson_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:crimson_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CRIMSON_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -5564,14 +6012,28 @@ static BLOCKS_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_CUT_COPPER_POOLS,
 };
-static BLOCKS_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -5618,14 +6080,28 @@ static BLOCKS_CUT_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CUT_RED_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_CUT_RED_SANDSTONE_POOLS,
 };
-static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cut_red_sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cut_red_sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cut_red_sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_RED_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -5654,14 +6130,28 @@ static BLOCKS_CUT_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CUT_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_CUT_SANDSTONE_POOLS,
 };
-static BLOCKS_CUT_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cut_sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CUT_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cut_sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cut_sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CUT_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -5695,7 +6185,9 @@ static BLOCKS_CYAN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CYAN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -5708,14 +6200,69 @@ static BLOCKS_CYAN_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_CYAN_BED: LootTable = LootTable {
     pools: BLOCKS_CYAN_BED_POOLS,
 };
-static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cyan_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cyan_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cyan_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cyan_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cyan_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_CYAN_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -5965,7 +6512,9 @@ static BLOCKS_DARK_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_DARK_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -6221,14 +6770,28 @@ static BLOCKS_DARK_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_DARK_OAK_SIGN: LootTable = LootTable {
     pools: BLOCKS_DARK_OAK_SIGN_POOLS,
 };
-static BLOCKS_DARK_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:dark_oak_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_DARK_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:dark_oak_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:dark_oak_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_DARK_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -6311,14 +6874,28 @@ static BLOCKS_DARK_PRISMARINE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_DARK_PRISMARINE: LootTable = LootTable {
     pools: BLOCKS_DARK_PRISMARINE_POOLS,
 };
-static BLOCKS_DARK_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:dark_prismarine_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_DARK_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:dark_prismarine_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:dark_prismarine_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_DARK_PRISMARINE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_PRISMARINE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -6487,7 +7064,7 @@ static BLOCKS_DEAD_BUSH_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 0i32,
         max_count: 2i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::Inverted(&LootCondition::Shears),
         bonus_formula: None,
     },
 ];
@@ -6668,7 +7245,9 @@ static BLOCKS_DECORATED_POT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+        properties: &[("cracked", "true")],
+    }),
     bonus_formula: None,
 }];
 static BLOCKS_DECORATED_POT_POOLS: &[LootPool] = &[LootPool {
@@ -6712,14 +7291,28 @@ static BLOCKS_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_DEEPSLATE: LootTable = LootTable {
     pools: BLOCKS_DEEPSLATE_POOLS,
 };
-static BLOCKS_DEEPSLATE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:deepslate_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_DEEPSLATE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:deepslate_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:deepslate_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_DEEPSLATE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -7008,14 +7601,28 @@ static BLOCKS_DEEPSLATE_REDSTONE_ORE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_DEEPSLATE_REDSTONE_ORE: LootTable = LootTable {
     pools: BLOCKS_DEEPSLATE_REDSTONE_ORE_POOLS,
 };
-static BLOCKS_DEEPSLATE_TILE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:deepslate_tile_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_DEEPSLATE_TILE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:deepslate_tile_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:deepslate_tile_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_DEEPSLATE_TILE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_TILE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -7162,14 +7769,28 @@ static BLOCKS_DIORITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_DIORITE: LootTable = LootTable {
     pools: BLOCKS_DIORITE_POOLS,
 };
-static BLOCKS_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:diorite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:diorite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:diorite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_DIORITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIORITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -7478,14 +8099,28 @@ static BLOCKS_END_STONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_END_STONE: LootTable = LootTable {
     pools: BLOCKS_END_STONE_POOLS,
 };
-static BLOCKS_END_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:end_stone_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_END_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:end_stone_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:end_stone_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_END_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_STONE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -7691,7 +8326,9 @@ static BLOCKS_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -7794,14 +8431,28 @@ static BLOCKS_EXPOSED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_EXPOSED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_EXPOSED_CUT_COPPER_POOLS,
 };
-static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:exposed_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:exposed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:exposed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -7881,7 +8532,7 @@ static BLOCKS_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::RandomChance { chance: 0.125f32 },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
@@ -8204,8 +8855,8 @@ pub static BLOCKS_GLASS_PANE: LootTable = LootTable {
 static BLOCKS_GLOW_LICHEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:glow_lichen",
     weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
+    min_count: -1i32,
+    max_count: -1i32,
     condition: LootCondition::Shears,
     bonus_formula: None,
 }];
@@ -8329,14 +8980,28 @@ static BLOCKS_GRANITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_GRANITE: LootTable = LootTable {
     pools: BLOCKS_GRANITE_POOLS,
 };
-static BLOCKS_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:granite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:granite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:granite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_GRANITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRANITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -8481,7 +9146,9 @@ static BLOCKS_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
@@ -8494,14 +9161,69 @@ static BLOCKS_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_GRAY_BED: LootTable = LootTable {
     pools: BLOCKS_GRAY_BED_POOLS,
 };
-static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:gray_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:gray_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:gray_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:gray_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:gray_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_GRAY_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -8715,7 +9437,9 @@ static BLOCKS_GREEN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_GREEN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -8728,14 +9452,69 @@ static BLOCKS_GREEN_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_GREEN_BED: LootTable = LootTable {
     pools: BLOCKS_GREEN_BED_POOLS,
 };
-static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:green_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:green_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:green_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:green_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:green_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_GREEN_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -9340,7 +10119,9 @@ static BLOCKS_IRON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_IRON_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -9458,7 +10239,9 @@ static BLOCKS_JUNGLE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_JUNGLE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -9688,14 +10471,28 @@ static BLOCKS_JUNGLE_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_JUNGLE_SIGN: LootTable = LootTable {
     pools: BLOCKS_JUNGLE_SIGN_POOLS,
 };
-static BLOCKS_JUNGLE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:jungle_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_JUNGLE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:jungle_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:jungle_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_JUNGLE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -9911,7 +10708,7 @@ static BLOCKS_LARGE_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::AllOf(&[
                 LootCondition::SurvivesExplosion,
                 LootCondition::RandomChance { chance: 0.125f32 },
@@ -9935,7 +10732,7 @@ static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::AllOf(&[
                 LootCondition::SurvivesExplosion,
                 LootCondition::RandomChance { chance: 0.125f32 },
@@ -9950,14 +10747,18 @@ static BLOCKS_LARGE_FERN_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("half", "lower")],
+        },
     },
     LootPool {
         entries: BLOCKS_LARGE_FERN_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("half", "upper")],
+        },
     },
 ];
 pub static BLOCKS_LARGE_FERN: LootTable = LootTable {
@@ -9981,14 +10782,93 @@ static BLOCKS_LAVA_CAULDRON_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_LAVA_CAULDRON: LootTable = LootTable {
     pools: BLOCKS_LAVA_CAULDRON_POOLS,
 };
-static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:leaf_litter",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:leaf_litter",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("segment_amount", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:leaf_litter",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:leaf_litter",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:leaf_litter",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "1")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:leaf_litter",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("segment_amount", "1")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_LEAF_LITTER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LEAF_LITTER_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -10058,7 +10938,9 @@ static BLOCKS_LIGHT_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIGHT_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10071,14 +10953,69 @@ static BLOCKS_LIGHT_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_LIGHT_BLUE_BED: LootTable = LootTable {
     pools: BLOCKS_LIGHT_BLUE_BED_POOLS,
 };
-static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:light_blue_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:light_blue_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_blue_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_blue_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_blue_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_LIGHT_BLUE_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -10292,7 +11229,9 @@ static BLOCKS_LIGHT_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIGHT_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10305,14 +11244,69 @@ static BLOCKS_LIGHT_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_LIGHT_GRAY_BED: LootTable = LootTable {
     pools: BLOCKS_LIGHT_GRAY_BED_POOLS,
 };
-static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:light_gray_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:light_gray_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_gray_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_gray_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:light_gray_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_LIGHT_GRAY_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -10544,7 +11538,9 @@ static BLOCKS_LILAC_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LILAC_POOLS: &[LootPool] = &[LootPool {
@@ -10616,7 +11612,9 @@ static BLOCKS_LIME_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIME_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10629,14 +11627,69 @@ static BLOCKS_LIME_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_LIME_BED: LootTable = LootTable {
     pools: BLOCKS_LIME_BED_POOLS,
 };
-static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:lime_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:lime_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:lime_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:lime_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:lime_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_LIME_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -10886,7 +11939,9 @@ static BLOCKS_MAGENTA_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_MAGENTA_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10899,14 +11954,69 @@ static BLOCKS_MAGENTA_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MAGENTA_BED: LootTable = LootTable {
     pools: BLOCKS_MAGENTA_BED_POOLS,
 };
-static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:magenta_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:magenta_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:magenta_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:magenta_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:magenta_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MAGENTA_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11138,7 +12248,9 @@ static BLOCKS_MANGROVE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_MANGROVE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -11305,7 +12417,9 @@ static BLOCKS_MANGROVE_PROPAGULE_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("age", "4")],
+    },
 }];
 pub static BLOCKS_MANGROVE_PROPAGULE: LootTable = LootTable {
     pools: BLOCKS_MANGROVE_PROPAGULE_POOLS,
@@ -11364,14 +12478,28 @@ static BLOCKS_MANGROVE_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MANGROVE_SIGN: LootTable = LootTable {
     pools: BLOCKS_MANGROVE_SIGN_POOLS,
 };
-static BLOCKS_MANGROVE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:mangrove_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MANGROVE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:mangrove_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:mangrove_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MANGROVE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11482,14 +12610,219 @@ static BLOCKS_MELON_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MELON: LootTable = LootTable {
     pools: BLOCKS_MELON_POOLS,
 };
-static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:melon_seeds",
-    weight: 1i32,
-    min_count: 0i32,
-    max_count: 0i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "0")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:melon_seeds",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "0")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MELON_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MELON_STEM_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11554,14 +12887,28 @@ static BLOCKS_MOSSY_COBBLESTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MOSSY_COBBLESTONE: LootTable = LootTable {
     pools: BLOCKS_MOSSY_COBBLESTONE_POOLS,
 };
-static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:mossy_cobblestone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:mossy_cobblestone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:mossy_cobblestone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_COBBLESTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11608,14 +12955,28 @@ static BLOCKS_MOSSY_COBBLESTONE_WALL_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MOSSY_COBBLESTONE_WALL: LootTable = LootTable {
     pools: BLOCKS_MOSSY_COBBLESTONE_WALL_POOLS,
 };
-static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:mossy_stone_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:mossy_stone_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:mossy_stone_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_STONE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11698,14 +13059,28 @@ static BLOCKS_MUD_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_MUD: LootTable = LootTable {
     pools: BLOCKS_MUD_POOLS,
 };
-static BLOCKS_MUD_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:mud_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_MUD_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:mud_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:mud_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_MUD_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUD_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -11855,14 +13230,28 @@ static BLOCKS_NETHER_BRICK_FENCE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_NETHER_BRICK_FENCE: LootTable = LootTable {
     pools: BLOCKS_NETHER_BRICK_FENCE_POOLS,
 };
-static BLOCKS_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:nether_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:nether_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:nether_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_NETHER_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -12005,14 +13394,28 @@ static BLOCKS_NETHER_SPROUTS_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_NETHER_SPROUTS: LootTable = LootTable {
     pools: BLOCKS_NETHER_SPROUTS_POOLS,
 };
-static BLOCKS_NETHER_WART_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:nether_wart",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 4i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static BLOCKS_NETHER_WART_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:nether_wart",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        },
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:nether_wart",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        }),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static BLOCKS_NETHER_WART_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_WART_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -12118,7 +13521,9 @@ static BLOCKS_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -12374,14 +13779,28 @@ static BLOCKS_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_OAK_SIGN: LootTable = LootTable {
     pools: BLOCKS_OAK_SIGN_POOLS,
 };
-static BLOCKS_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:oak_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:oak_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:oak_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -12541,7 +13960,9 @@ static BLOCKS_ORANGE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ORANGE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -12554,14 +13975,69 @@ static BLOCKS_ORANGE_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_ORANGE_BED: LootTable = LootTable {
     pools: BLOCKS_ORANGE_BED_POOLS,
 };
-static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:orange_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:orange_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:orange_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:orange_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:orange_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_ORANGE_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -12901,7 +14377,9 @@ static BLOCKS_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -13004,14 +14482,28 @@ static BLOCKS_OXIDIZED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_OXIDIZED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_OXIDIZED_CUT_COPPER_POOLS,
 };
-static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:oxidized_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:oxidized_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:oxidized_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -13135,7 +14627,9 @@ static BLOCKS_PALE_MOSS_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("bottom", "true")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PALE_MOSS_CARPET_POOLS: &[LootPool] = &[LootPool {
@@ -13171,7 +14665,9 @@ static BLOCKS_PALE_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PALE_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -13401,14 +14897,28 @@ static BLOCKS_PALE_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PALE_OAK_SIGN: LootTable = LootTable {
     pools: BLOCKS_PALE_OAK_SIGN_POOLS,
 };
-static BLOCKS_PALE_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:pale_oak_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PALE_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:pale_oak_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pale_oak_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PALE_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -13496,7 +15006,9 @@ static BLOCKS_PEONY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PEONY_POOLS: &[LootPool] = &[LootPool {
@@ -13509,14 +15021,28 @@ static BLOCKS_PEONY_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PEONY: LootTable = LootTable {
     pools: BLOCKS_PEONY_POOLS,
 };
-static BLOCKS_PETRIFIED_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:petrified_oak_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PETRIFIED_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:petrified_oak_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:petrified_oak_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PETRIFIED_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PETRIFIED_OAK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -13568,7 +15094,9 @@ static BLOCKS_PINK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PINK_BED_POOLS: &[LootPool] = &[LootPool {
@@ -13581,14 +15109,69 @@ static BLOCKS_PINK_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PINK_BED: LootTable = LootTable {
     pools: BLOCKS_PINK_BED_POOLS,
 };
-static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:pink_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:pink_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PINK_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -13689,14 +15272,93 @@ static BLOCKS_PINK_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PINK_GLAZED_TERRACOTTA: LootTable = LootTable {
     pools: BLOCKS_PINK_GLAZED_TERRACOTTA_POOLS,
 };
-static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:pink_petals",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:pink_petals",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("flower_amount", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_petals",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_petals",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_petals",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "1")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pink_petals",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "1")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PINK_PETALS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_PETALS_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -13839,7 +15501,14 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "0")],
+            },
+            LootCondition::BlockStateProperty {
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13847,7 +15516,24 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::AllOf(&[
+                LootCondition::BlockStateProperty {
+                    properties: &[("age", "0")],
+                },
+                LootCondition::BlockStateProperty {
+                    properties: &[("half", "lower")],
+                },
+            ])),
+            LootCondition::AllOf(&[
+                LootCondition::BlockStateProperty {
+                    properties: &[("age", "1")],
+                },
+                LootCondition::BlockStateProperty {
+                    properties: &[("half", "lower")],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13855,7 +15541,34 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "0")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "1")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+            ]),
+            LootCondition::AllOf(&[
+                LootCondition::BlockStateProperty {
+                    properties: &[("age", "2")],
+                },
+                LootCondition::BlockStateProperty {
+                    properties: &[("half", "lower")],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13863,7 +15576,42 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "0")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "1")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "2")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+            ]),
+            LootCondition::AllOf(&[
+                LootCondition::BlockStateProperty {
+                    properties: &[("age", "3")],
+                },
+                LootCondition::BlockStateProperty {
+                    properties: &[("half", "lower")],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13871,7 +15619,50 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "0")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "1")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "2")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+                LootCondition::Inverted(&LootCondition::AllOf(&[
+                    LootCondition::BlockStateProperty {
+                        properties: &[("age", "3")],
+                    },
+                    LootCondition::BlockStateProperty {
+                        properties: &[("half", "lower")],
+                    },
+                ])),
+            ]),
+            LootCondition::AllOf(&[
+                LootCondition::BlockStateProperty {
+                    properties: &[("age", "4")],
+                },
+                LootCondition::BlockStateProperty {
+                    properties: &[("half", "lower")],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -13890,7 +15681,9 @@ static BLOCKS_PITCHER_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PITCHER_PLANT_POOLS: &[LootPool] = &[LootPool {
@@ -13988,14 +15781,28 @@ static BLOCKS_POLISHED_ANDESITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_ANDESITE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_ANDESITE_POOLS,
 };
-static BLOCKS_POLISHED_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_andesite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_andesite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_andesite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_ANDESITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_ANDESITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14060,14 +15867,28 @@ static BLOCKS_POLISHED_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_BLACKSTONE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_BLACKSTONE_POOLS,
 };
-static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_blackstone_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_blackstone_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_blackstone_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14168,14 +15989,28 @@ static BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool
 pub static BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE_POOLS,
 };
-static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_blackstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_blackstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_blackstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14240,14 +16075,28 @@ static BLOCKS_POLISHED_CINNABAR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_CINNABAR: LootTable = LootTable {
     pools: BLOCKS_POLISHED_CINNABAR_POOLS,
 };
-static BLOCKS_POLISHED_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_cinnabar_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_cinnabar_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_cinnabar_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_CINNABAR_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_CINNABAR_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14312,14 +16161,28 @@ static BLOCKS_POLISHED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_DEEPSLATE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_DEEPSLATE_POOLS,
 };
-static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_deepslate_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_deepslate_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_deepslate_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DEEPSLATE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14384,14 +16247,28 @@ static BLOCKS_POLISHED_DIORITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_DIORITE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_DIORITE_POOLS,
 };
-static BLOCKS_POLISHED_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_diorite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_diorite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_diorite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_DIORITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DIORITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14438,14 +16315,28 @@ static BLOCKS_POLISHED_GRANITE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_GRANITE: LootTable = LootTable {
     pools: BLOCKS_POLISHED_GRANITE_POOLS,
 };
-static BLOCKS_POLISHED_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_granite_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_granite_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_granite_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_GRANITE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_GRANITE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14492,14 +16383,28 @@ static BLOCKS_POLISHED_SULFUR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_SULFUR: LootTable = LootTable {
     pools: BLOCKS_POLISHED_SULFUR_POOLS,
 };
-static BLOCKS_POLISHED_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_sulfur_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_sulfur_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_sulfur_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_SULFUR_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_SULFUR_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14564,14 +16469,28 @@ static BLOCKS_POLISHED_TUFF_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_POLISHED_TUFF: LootTable = LootTable {
     pools: BLOCKS_POLISHED_TUFF_POOLS,
 };
-static BLOCKS_POLISHED_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:polished_tuff_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_POLISHED_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:polished_tuff_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:polished_tuff_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_POLISHED_TUFF_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_TUFF_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -14676,14 +16595,18 @@ static BLOCKS_POTATOES_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
     },
     LootPool {
         entries: BLOCKS_POTATOES_POOL2_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_POTATOES: LootTable = LootTable {
@@ -16095,14 +18018,28 @@ static BLOCKS_PRISMARINE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PRISMARINE: LootTable = LootTable {
     pools: BLOCKS_PRISMARINE_POOLS,
 };
-static BLOCKS_PRISMARINE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:prismarine_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PRISMARINE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:prismarine_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:prismarine_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PRISMARINE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16149,14 +18086,28 @@ static BLOCKS_PRISMARINE_BRICKS_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PRISMARINE_BRICKS: LootTable = LootTable {
     pools: BLOCKS_PRISMARINE_BRICKS_POOLS,
 };
-static BLOCKS_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:prismarine_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:prismarine_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:prismarine_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PRISMARINE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16221,14 +18172,219 @@ static BLOCKS_PUMPKIN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PUMPKIN: LootTable = LootTable {
     pools: BLOCKS_PUMPKIN_POOLS,
 };
-static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:pumpkin_seeds",
-    weight: 1i32,
-    min_count: 0i32,
-    max_count: 0i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 0i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("age", "0")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:pumpkin_seeds",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "7")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "1")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("age", "0")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PUMPKIN_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16262,7 +18418,9 @@ static BLOCKS_PURPLE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PURPLE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -16275,14 +18433,69 @@ static BLOCKS_PURPLE_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PURPLE_BED: LootTable = LootTable {
     pools: BLOCKS_PURPLE_BED_POOLS,
 };
-static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:purple_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:purple_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:purple_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:purple_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:purple_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PURPLE_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16509,14 +18722,28 @@ static BLOCKS_PURPUR_PILLAR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_PURPUR_PILLAR: LootTable = LootTable {
     pools: BLOCKS_PURPUR_PILLAR_POOLS,
 };
-static BLOCKS_PURPUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:purpur_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_PURPUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:purpur_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:purpur_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_PURPUR_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPUR_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16599,14 +18826,28 @@ static BLOCKS_QUARTZ_PILLAR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_QUARTZ_PILLAR: LootTable = LootTable {
     pools: BLOCKS_QUARTZ_PILLAR_POOLS,
 };
-static BLOCKS_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:quartz_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:quartz_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:quartz_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_QUARTZ_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_QUARTZ_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16730,7 +18971,9 @@ static BLOCKS_RED_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_RED_BED_POOLS: &[LootPool] = &[LootPool {
@@ -16743,14 +18986,69 @@ static BLOCKS_RED_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_RED_BED: LootTable = LootTable {
     pools: BLOCKS_RED_BED_POOLS,
 };
-static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:red_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:red_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:red_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:red_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:red_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_RED_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -16897,14 +19195,28 @@ static BLOCKS_RED_MUSHROOM_BLOCK_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_RED_MUSHROOM_BLOCK: LootTable = LootTable {
     pools: BLOCKS_RED_MUSHROOM_BLOCK_POOLS,
 };
-static BLOCKS_RED_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:red_nether_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_RED_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:red_nether_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:red_nether_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_RED_NETHER_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_NETHER_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17005,14 +19317,28 @@ static BLOCKS_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_RED_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_RED_SANDSTONE_POOLS,
 };
-static BLOCKS_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:red_sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:red_sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:red_sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17307,14 +19633,28 @@ static BLOCKS_RESIN_BLOCK_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_RESIN_BLOCK: LootTable = LootTable {
     pools: BLOCKS_RESIN_BLOCK_POOLS,
 };
-static BLOCKS_RESIN_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:resin_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_RESIN_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:resin_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:resin_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_RESIN_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17382,8 +19722,8 @@ pub static BLOCKS_RESIN_BRICKS: LootTable = LootTable {
 static BLOCKS_RESIN_CLUMP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:resin_clump",
     weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
+    min_count: -1i32,
+    max_count: -1i32,
     condition: LootCondition::None,
     bonus_formula: None,
 }];
@@ -17438,7 +19778,9 @@ static BLOCKS_ROSE_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ROSE_BUSH_POOLS: &[LootPool] = &[LootPool {
@@ -17487,14 +19829,28 @@ static BLOCKS_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_SANDSTONE_POOLS,
 };
-static BLOCKS_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17634,8 +19990,8 @@ pub static BLOCKS_SCULK_SHRIEKER: LootTable = LootTable {
 static BLOCKS_SCULK_VEIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sculk_vein",
     weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
+    min_count: -1i32,
+    max_count: -1i32,
     condition: LootCondition::SilkTouch,
     bonus_formula: None,
 }];
@@ -17677,14 +20033,69 @@ static BLOCKS_SEA_LANTERN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SEA_LANTERN: LootTable = LootTable {
     pools: BLOCKS_SEA_LANTERN_POOLS,
 };
-static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:sea_pickle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:sea_pickle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("pickles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sea_pickle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("pickles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sea_pickle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("pickles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sea_pickle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("pickles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SEA_PICKLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SEA_PICKLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17746,7 +20157,7 @@ static BLOCKS_SHORT_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::RandomChance { chance: 0.125f32 },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
@@ -17942,14 +20353,28 @@ static BLOCKS_SMOOTH_QUARTZ_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SMOOTH_QUARTZ: LootTable = LootTable {
     pools: BLOCKS_SMOOTH_QUARTZ_POOLS,
 };
-static BLOCKS_SMOOTH_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:smooth_quartz_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SMOOTH_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:smooth_quartz_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:smooth_quartz_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SMOOTH_QUARTZ_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_QUARTZ_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -17996,14 +20421,28 @@ static BLOCKS_SMOOTH_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SMOOTH_RED_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_SMOOTH_RED_SANDSTONE_POOLS,
 };
-static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:smooth_red_sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:smooth_red_sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:smooth_red_sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -18050,14 +20489,28 @@ static BLOCKS_SMOOTH_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SMOOTH_SANDSTONE: LootTable = LootTable {
     pools: BLOCKS_SMOOTH_SANDSTONE_POOLS,
 };
-static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:smooth_sandstone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:smooth_sandstone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:smooth_sandstone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_SANDSTONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -18104,14 +20557,28 @@ static BLOCKS_SMOOTH_STONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SMOOTH_STONE: LootTable = LootTable {
     pools: BLOCKS_SMOOTH_STONE_POOLS,
 };
-static BLOCKS_SMOOTH_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:smooth_stone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SMOOTH_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:smooth_stone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:smooth_stone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SMOOTH_STONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_STONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -18146,7 +20613,12 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "1")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18154,7 +20626,17 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "2")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18162,7 +20644,20 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 3i32,
         max_count: 3i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "3")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18170,7 +20665,23 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 4i32,
         max_count: 4i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "4")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18178,7 +20689,26 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 5i32,
         max_count: 5i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "5")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18186,7 +20716,29 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 6i32,
         max_count: 6i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "5")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "6")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18194,7 +20746,32 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 7i32,
         max_count: 7i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "5")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "6")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "7")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18202,7 +20779,35 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 8i32,
         max_count: 8i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::NoSilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "5")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "6")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "7")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "8")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18210,7 +20815,12 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouch,
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "1")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18218,7 +20828,17 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "2")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18226,7 +20846,20 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 3i32,
         max_count: 3i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "3")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18234,7 +20867,23 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 4i32,
         max_count: 4i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "4")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18242,7 +20891,26 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 5i32,
         max_count: 5i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "5")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18250,7 +20918,29 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 6i32,
         max_count: 6i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "5")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "6")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18258,7 +20948,32 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 7i32,
         max_count: 7i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[
+                LootCondition::SilkTouch,
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "1")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "2")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "3")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "4")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "5")],
+                }),
+                LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                    properties: &[("layers", "6")],
+                }),
+            ]),
+            LootCondition::BlockStateProperty {
+                properties: &[("layers", "7")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18266,7 +20981,30 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouch,
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "1")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "5")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "6")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("layers", "7")],
+            }),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -18478,7 +21216,9 @@ static BLOCKS_SPRUCE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_SPRUCE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -18708,14 +21448,28 @@ static BLOCKS_SPRUCE_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SPRUCE_SIGN: LootTable = LootTable {
     pools: BLOCKS_SPRUCE_SIGN_POOLS,
 };
-static BLOCKS_SPRUCE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:spruce_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SPRUCE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:spruce_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:spruce_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SPRUCE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -18829,14 +21583,28 @@ static BLOCKS_STONE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_STONE: LootTable = LootTable {
     pools: BLOCKS_STONE_POOLS,
 };
-static BLOCKS_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:stone_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:stone_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:stone_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -18937,14 +21705,28 @@ static BLOCKS_STONE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_STONE_PRESSURE_PLATE: LootTable = LootTable {
     pools: BLOCKS_STONE_PRESSURE_PLATE_POOLS,
 };
-static BLOCKS_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:stone_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:stone_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:stone_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_STONE_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -19441,14 +22223,28 @@ static BLOCKS_SULFUR_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SULFUR: LootTable = LootTable {
     pools: BLOCKS_SULFUR_POOLS,
 };
-static BLOCKS_SULFUR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:sulfur_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SULFUR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:sulfur_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sulfur_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SULFUR_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -19513,14 +22309,28 @@ static BLOCKS_SULFUR_BRICKS_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_SULFUR_BRICKS: LootTable = LootTable {
     pools: BLOCKS_SULFUR_BRICKS_POOLS,
 };
-static BLOCKS_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:sulfur_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:sulfur_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:sulfur_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_SULFUR_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -19590,7 +22400,9 @@ static BLOCKS_SUNFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_SUNFLOWER_POOLS: &[LootPool] = &[LootPool {
@@ -19614,18 +22426,18 @@ pub static BLOCKS_SUSPICIOUS_SAND: LootTable = LootTable {
 static BLOCKS_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
     weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
+    min_count: 2i32,
+    max_count: 3i32,
     condition: LootCondition::None,
-    bonus_formula: None,
+    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
     weight: 1i32,
     min_count: 1i32,
-    max_count: 1i32,
+    max_count: 2i32,
     condition: LootCondition::None,
-    bonus_formula: None,
+    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -19633,14 +22445,18 @@ static BLOCKS_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "3")],
+        },
     },
     LootPool {
         entries: BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "2")],
+        },
     },
 ];
 pub static BLOCKS_SWEET_BERRY_BUSH: LootTable = LootTable {
@@ -19679,7 +22495,7 @@ static BLOCKS_TALL_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::AllOf(&[
                 LootCondition::SurvivesExplosion,
                 LootCondition::RandomChance { chance: 0.125f32 },
@@ -19703,7 +22519,7 @@ static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
         min_count: 1i32,
         max_count: 1i32,
         condition: LootCondition::AllOf(&[
-            LootCondition::NoSilkTouchOrShears,
+            LootCondition::Inverted(&LootCondition::Shears),
             LootCondition::AllOf(&[
                 LootCondition::SurvivesExplosion,
                 LootCondition::RandomChance { chance: 0.125f32 },
@@ -19718,14 +22534,18 @@ static BLOCKS_TALL_GRASS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("half", "lower")],
+        },
     },
     LootPool {
         entries: BLOCKS_TALL_GRASS_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("half", "upper")],
+        },
     },
 ];
 pub static BLOCKS_TALL_GRASS: LootTable = LootTable {
@@ -19808,7 +22628,9 @@ static BLOCKS_TNT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("unstable", "false")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_TNT_POOLS: &[LootPool] = &[LootPool {
@@ -20018,14 +22840,28 @@ static BLOCKS_TUFF_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_TUFF: LootTable = LootTable {
     pools: BLOCKS_TUFF_POOLS,
 };
-static BLOCKS_TUFF_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:tuff_brick_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_TUFF_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:tuff_brick_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:tuff_brick_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_TUFF_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_BRICK_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -20090,14 +22926,28 @@ static BLOCKS_TUFF_BRICKS_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_TUFF_BRICKS: LootTable = LootTable {
     pools: BLOCKS_TUFF_BRICKS_POOLS,
 };
-static BLOCKS_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:tuff_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:tuff_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:tuff_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_TUFF_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -20291,7 +23141,9 @@ static BLOCKS_WARPED_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WARPED_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -20515,14 +23367,28 @@ static BLOCKS_WARPED_SIGN_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WARPED_SIGN: LootTable = LootTable {
     pools: BLOCKS_WARPED_SIGN_POOLS,
 };
-static BLOCKS_WARPED_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:warped_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WARPED_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:warped_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:warped_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WARPED_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -20736,7 +23602,9 @@ static BLOCKS_WAXED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -20839,14 +23707,28 @@ static BLOCKS_WAXED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WAXED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_WAXED_CUT_COPPER_POOLS,
 };
-static BLOCKS_WAXED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:waxed_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WAXED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:waxed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:waxed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WAXED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -20988,7 +23870,9 @@ static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21091,14 +23975,28 @@ static BLOCKS_WAXED_EXPOSED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WAXED_EXPOSED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_WAXED_EXPOSED_CUT_COPPER_POOLS,
 };
-static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:waxed_exposed_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:waxed_exposed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:waxed_exposed_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -21276,7 +24174,9 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21379,14 +24279,28 @@ static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WAXED_OXIDIZED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_WAXED_OXIDIZED_CUT_COPPER_POOLS,
 };
-static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:waxed_oxidized_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:waxed_oxidized_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:waxed_oxidized_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -21546,7 +24460,9 @@ static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21649,14 +24565,28 @@ static BLOCKS_WAXED_WEATHERED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WAXED_WEATHERED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_WAXED_WEATHERED_CUT_COPPER_POOLS,
 };
-static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:waxed_weathered_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:waxed_weathered_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:waxed_weathered_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -21816,7 +24746,9 @@ static BLOCKS_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21919,14 +24851,28 @@ static BLOCKS_WEATHERED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WEATHERED_CUT_COPPER: LootTable = LootTable {
     pools: BLOCKS_WEATHERED_CUT_COPPER_POOLS,
 };
-static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:weathered_cut_copper_slab",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:weathered_cut_copper_slab",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:weathered_cut_copper_slab",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("type", "double")],
+        }),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -22063,7 +25009,9 @@ static BLOCKS_WHEAT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -22071,7 +25019,9 @@ static BLOCKS_WHEAT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        }),
         bonus_formula: None,
     },
 ];
@@ -22099,7 +25049,9 @@ static BLOCKS_WHEAT_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_WHEAT: LootTable = LootTable {
@@ -22128,7 +25080,9 @@ static BLOCKS_WHITE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WHITE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -22141,14 +25095,69 @@ static BLOCKS_WHITE_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WHITE_BED: LootTable = LootTable {
     pools: BLOCKS_WHITE_BED_POOLS,
 };
-static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:white_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:white_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:white_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:white_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:white_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WHITE_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -22357,14 +25366,93 @@ static BLOCKS_WHITE_WOOL_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_WHITE_WOOL: LootTable = LootTable {
     pools: BLOCKS_WHITE_WOOL_POOLS,
 };
-static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:wildflowers",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:wildflowers",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("flower_amount", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:wildflowers",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:wildflowers",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:wildflowers",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "1")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:wildflowers",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "2")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("flower_amount", "1")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_WILDFLOWERS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WILDFLOWERS_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -22434,7 +25522,9 @@ static BLOCKS_YELLOW_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_YELLOW_BED_POOLS: &[LootPool] = &[LootPool {
@@ -22447,14 +25537,69 @@ static BLOCKS_YELLOW_BED_POOLS: &[LootPool] = &[LootPool {
 pub static BLOCKS_YELLOW_BED: LootTable = LootTable {
     pools: BLOCKS_YELLOW_BED_POOLS,
 };
-static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:yellow_candle",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:yellow_candle",
+        weight: 1i32,
+        min_count: 4i32,
+        max_count: 4i32,
+        condition: LootCondition::BlockStateProperty {
+            properties: &[("candles", "4")],
+        },
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:yellow_candle",
+        weight: 1i32,
+        min_count: 3i32,
+        max_count: 3i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:yellow_candle",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 2i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            },
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:yellow_candle",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AllOf(&[
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "4")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "3")],
+            }),
+            LootCondition::Inverted(&LootCondition::BlockStateProperty {
+                properties: &[("candles", "2")],
+            }),
+        ]),
+        bonus_formula: None,
+    },
+];
 static BLOCKS_YELLOW_CANDLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -34997,7 +38142,9 @@ static HARVEST_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        properties: &[("age", "3")],
+    },
     bonus_formula: None,
 }];
 static HARVEST_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {

--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -8,6 +8,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:miner_pottery_sherd",
@@ -16,6 +18,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:prize_pottery_sherd",
@@ -24,6 +28,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:skull_pottery_sherd",
@@ -32,6 +38,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -40,6 +48,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tnt",
@@ -48,6 +58,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -56,6 +68,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -64,6 +78,8 @@ static ARCHAEOLOGY_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_DESERT_PYRAMID_POOLS: &[LootPool] = &[LootPool {
@@ -84,6 +100,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brewer_pottery_sherd",
@@ -92,6 +110,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brick",
@@ -100,6 +120,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -108,6 +130,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -116,6 +140,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:suspicious_stew",
@@ -124,6 +150,8 @@ static ARCHAEOLOGY_DESERT_WELL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_DESERT_WELL_POOLS: &[LootPool] = &[LootPool {
@@ -144,6 +172,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:explorer_pottery_sherd",
@@ -152,6 +182,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:mourner_pottery_sherd",
@@ -160,6 +192,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:plenty_pottery_sherd",
@@ -168,6 +202,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_axe",
@@ -176,6 +212,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -184,6 +222,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -192,6 +232,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_hoe",
@@ -200,6 +242,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -208,6 +252,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -216,6 +262,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_OCEAN_RUIN_COLD_POOLS: &[LootPool] = &[LootPool {
@@ -236,6 +284,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:shelter_pottery_sherd",
@@ -244,6 +294,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snort_pottery_sherd",
@@ -252,6 +304,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sniffer_egg",
@@ -260,6 +314,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_axe",
@@ -268,6 +324,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -276,6 +334,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -284,6 +344,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_hoe",
@@ -292,6 +354,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -300,6 +364,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -308,6 +374,8 @@ static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_OCEAN_RUIN_WARM_POOLS: &[LootPool] = &[LootPool {
@@ -328,6 +396,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -336,6 +406,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_hoe",
@@ -344,6 +416,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:clay",
@@ -352,6 +426,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brick",
@@ -360,6 +436,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_dye",
@@ -368,6 +446,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_dye",
@@ -376,6 +456,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_blue_dye",
@@ -384,6 +466,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:white_dye",
@@ -392,6 +476,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:orange_dye",
@@ -400,6 +486,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_candle",
@@ -408,6 +496,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:green_candle",
@@ -416,6 +506,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:purple_candle",
@@ -424,6 +516,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_candle",
@@ -432,6 +526,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magenta_stained_glass_pane",
@@ -440,6 +536,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pink_stained_glass_pane",
@@ -448,6 +546,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_stained_glass_pane",
@@ -456,6 +556,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_blue_stained_glass_pane",
@@ -464,6 +566,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_stained_glass_pane",
@@ -472,6 +576,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_stained_glass_pane",
@@ -480,6 +586,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:purple_stained_glass_pane",
@@ -488,6 +596,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_hanging_sign",
@@ -496,6 +606,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_hanging_sign",
@@ -504,6 +616,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -512,6 +626,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -520,6 +636,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -528,6 +646,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -536,6 +656,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_bush",
@@ -544,6 +666,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flower_pot",
@@ -552,6 +676,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -560,6 +686,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lead",
@@ -568,6 +696,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_TRAIL_RUINS_COMMON_POOLS: &[LootPool] = &[LootPool {
@@ -588,6 +718,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:danger_pottery_sherd",
@@ -596,6 +728,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:friend_pottery_sherd",
@@ -604,6 +738,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:heart_pottery_sherd",
@@ -612,6 +748,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:heartbreak_pottery_sherd",
@@ -620,6 +758,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:howl_pottery_sherd",
@@ -628,6 +768,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sheaf_pottery_sherd",
@@ -636,6 +778,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wayfinder_armor_trim_smithing_template",
@@ -644,6 +788,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raiser_armor_trim_smithing_template",
@@ -652,6 +798,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:shaper_armor_trim_smithing_template",
@@ -660,6 +808,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:host_armor_trim_smithing_template",
@@ -668,6 +818,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_relic",
@@ -676,6 +828,8 @@ static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ARCHAEOLOGY_TRAIL_RUINS_RARE_POOLS: &[LootPool] = &[LootPool {
@@ -695,6 +849,8 @@ static BLOCKS_ACACIA_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_BUTTON_POOL0_ENTRIES,
@@ -715,6 +871,8 @@ static BLOCKS_ACACIA_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_DOOR_POOL0_ENTRIES,
@@ -733,6 +891,8 @@ static BLOCKS_ACACIA_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_FENCE_POOL0_ENTRIES,
@@ -751,6 +911,8 @@ static BLOCKS_ACACIA_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_FENCE_GATE_POOL0_ENTRIES,
@@ -769,6 +931,8 @@ static BLOCKS_ACACIA_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_HANGING_SIGN_POOL0_ENTRIES,
@@ -788,6 +952,8 @@ static BLOCKS_ACACIA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:acacia_sapling",
@@ -804,6 +970,8 @@ static BLOCKS_ACACIA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_ACACIA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -815,6 +983,8 @@ static BLOCKS_ACACIA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_ACACIA_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -842,6 +1012,8 @@ static BLOCKS_ACACIA_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_LOG_POOL0_ENTRIES,
@@ -860,6 +1032,8 @@ static BLOCKS_ACACIA_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_PLANKS_POOL0_ENTRIES,
@@ -878,6 +1052,8 @@ static BLOCKS_ACACIA_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -896,6 +1072,8 @@ static BLOCKS_ACACIA_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_SAPLING_POOL0_ENTRIES,
@@ -914,6 +1092,8 @@ static BLOCKS_ACACIA_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_SHELF_POOL0_ENTRIES,
@@ -932,6 +1112,8 @@ static BLOCKS_ACACIA_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_SIGN_POOL0_ENTRIES,
@@ -953,6 +1135,8 @@ static BLOCKS_ACACIA_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:acacia_slab",
@@ -963,6 +1147,8 @@ static BLOCKS_ACACIA_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_ACACIA_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -982,6 +1168,8 @@ static BLOCKS_ACACIA_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_STAIRS_POOL0_ENTRIES,
@@ -1000,6 +1188,8 @@ static BLOCKS_ACACIA_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_TRAPDOOR_POOL0_ENTRIES,
@@ -1018,6 +1208,8 @@ static BLOCKS_ACACIA_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACACIA_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACACIA_WOOD_POOL0_ENTRIES,
@@ -1036,6 +1228,8 @@ static BLOCKS_ACTIVATOR_RAIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ACTIVATOR_RAIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ACTIVATOR_RAIL_POOL0_ENTRIES,
@@ -1054,6 +1248,8 @@ static BLOCKS_ALLIUM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ALLIUM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ALLIUM_POOL0_ENTRIES,
@@ -1072,6 +1268,8 @@ static BLOCKS_AMETHYST_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_AMETHYST_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_AMETHYST_BLOCK_POOL0_ENTRIES,
@@ -1091,6 +1289,8 @@ static BLOCKS_AMETHYST_CLUSTER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:amethyst_shard",
@@ -1099,6 +1299,8 @@ static BLOCKS_AMETHYST_CLUSTER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:amethyst_shard",
@@ -1107,6 +1309,8 @@ static BLOCKS_AMETHYST_CLUSTER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_AMETHYST_CLUSTER_POOLS: &[LootPool] = &[LootPool {
@@ -1126,6 +1330,8 @@ static BLOCKS_ANCIENT_DEBRIS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ANCIENT_DEBRIS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANCIENT_DEBRIS_POOL0_ENTRIES,
@@ -1144,6 +1350,8 @@ static BLOCKS_ANDESITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ANDESITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANDESITE_POOL0_ENTRIES,
@@ -1165,6 +1373,8 @@ static BLOCKS_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:andesite_slab",
@@ -1175,6 +1385,8 @@ static BLOCKS_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_ANDESITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -1194,6 +1406,8 @@ static BLOCKS_ANDESITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ANDESITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANDESITE_STAIRS_POOL0_ENTRIES,
@@ -1212,6 +1426,8 @@ static BLOCKS_ANDESITE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ANDESITE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANDESITE_WALL_POOL0_ENTRIES,
@@ -1230,6 +1446,8 @@ static BLOCKS_ANVIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ANVIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ANVIL_POOL0_ENTRIES,
@@ -1248,6 +1466,8 @@ static BLOCKS_ATTACHED_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 0i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_ATTACHED_MELON_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ATTACHED_MELON_STEM_POOL0_ENTRIES,
@@ -1266,6 +1486,8 @@ static BLOCKS_ATTACHED_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 0i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_ATTACHED_PUMPKIN_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ATTACHED_PUMPKIN_STEM_POOL0_ENTRIES,
@@ -1284,6 +1506,8 @@ static BLOCKS_AZALEA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_AZALEA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_AZALEA_POOL0_ENTRIES,
@@ -1303,6 +1527,8 @@ static BLOCKS_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:azalea",
@@ -1319,6 +1545,8 @@ static BLOCKS_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -1330,6 +1558,8 @@ static BLOCKS_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_AZALEA_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -1357,6 +1587,8 @@ static BLOCKS_AZURE_BLUET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_AZURE_BLUET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_AZURE_BLUET_POOL0_ENTRIES,
@@ -1375,6 +1607,8 @@ static BLOCKS_BAMBOO_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_POOL0_ENTRIES,
@@ -1393,6 +1627,8 @@ static BLOCKS_BAMBOO_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_BLOCK_POOL0_ENTRIES,
@@ -1411,6 +1647,8 @@ static BLOCKS_BAMBOO_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_BUTTON_POOL0_ENTRIES,
@@ -1431,6 +1669,8 @@ static BLOCKS_BAMBOO_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_DOOR_POOL0_ENTRIES,
@@ -1449,6 +1689,8 @@ static BLOCKS_BAMBOO_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_FENCE_POOL0_ENTRIES,
@@ -1467,6 +1709,8 @@ static BLOCKS_BAMBOO_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_FENCE_GATE_POOL0_ENTRIES,
@@ -1485,6 +1729,8 @@ static BLOCKS_BAMBOO_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_HANGING_SIGN_POOL0_ENTRIES,
@@ -1503,6 +1749,8 @@ static BLOCKS_BAMBOO_MOSAIC_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_MOSAIC_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_MOSAIC_POOL0_ENTRIES,
@@ -1524,6 +1772,8 @@ static BLOCKS_BAMBOO_MOSAIC_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:bamboo_mosaic_slab",
@@ -1534,6 +1784,8 @@ static BLOCKS_BAMBOO_MOSAIC_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BAMBOO_MOSAIC_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -1553,6 +1805,8 @@ static BLOCKS_BAMBOO_MOSAIC_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_MOSAIC_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_MOSAIC_STAIRS_POOL0_ENTRIES,
@@ -1571,6 +1825,8 @@ static BLOCKS_BAMBOO_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_PLANKS_POOL0_ENTRIES,
@@ -1589,6 +1845,8 @@ static BLOCKS_BAMBOO_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -1607,6 +1865,8 @@ static BLOCKS_BAMBOO_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_SAPLING_POOL0_ENTRIES,
@@ -1625,6 +1885,8 @@ static BLOCKS_BAMBOO_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_SHELF_POOL0_ENTRIES,
@@ -1643,6 +1905,8 @@ static BLOCKS_BAMBOO_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_SIGN_POOL0_ENTRIES,
@@ -1664,6 +1928,8 @@ static BLOCKS_BAMBOO_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:bamboo_slab",
@@ -1674,6 +1940,8 @@ static BLOCKS_BAMBOO_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BAMBOO_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -1693,6 +1961,8 @@ static BLOCKS_BAMBOO_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_STAIRS_POOL0_ENTRIES,
@@ -1711,6 +1981,8 @@ static BLOCKS_BAMBOO_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BAMBOO_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BAMBOO_TRAPDOOR_POOL0_ENTRIES,
@@ -1729,6 +2001,8 @@ static BLOCKS_BARREL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BARREL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BARREL_POOL0_ENTRIES,
@@ -1747,6 +2021,8 @@ static BLOCKS_BASALT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BASALT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BASALT_POOL0_ENTRIES,
@@ -1765,6 +2041,8 @@ static BLOCKS_BEACON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BEACON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BEACON_POOL0_ENTRIES,
@@ -1783,6 +2061,8 @@ static BLOCKS_BEE_NEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BEE_NEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BEE_NEST_POOL0_ENTRIES,
@@ -1802,6 +2082,8 @@ static BLOCKS_BEEHIVE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beehive",
@@ -1810,6 +2092,8 @@ static BLOCKS_BEEHIVE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_BEEHIVE_POOLS: &[LootPool] = &[LootPool {
@@ -1832,6 +2116,8 @@ static BLOCKS_BEETROOTS_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "3")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -1842,6 +2128,8 @@ static BLOCKS_BEETROOTS_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "3")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BEETROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -1854,6 +2142,8 @@ static BLOCKS_BEETROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         extra: 3i32,
         probability: 0.5714286f32,
     }),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_BEETROOTS_POOLS: &[LootPool] = &[
     LootPool {
@@ -1883,6 +2173,8 @@ static BLOCKS_BELL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BELL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BELL_POOL0_ENTRIES,
@@ -1901,6 +2193,8 @@ static BLOCKS_BIG_DRIPLEAF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIG_DRIPLEAF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIG_DRIPLEAF_POOL0_ENTRIES,
@@ -1919,6 +2213,8 @@ static BLOCKS_BIG_DRIPLEAF_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIG_DRIPLEAF_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIG_DRIPLEAF_STEM_POOL0_ENTRIES,
@@ -1937,6 +2233,8 @@ static BLOCKS_BIRCH_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_BUTTON_POOL0_ENTRIES,
@@ -1957,6 +2255,8 @@ static BLOCKS_BIRCH_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_DOOR_POOL0_ENTRIES,
@@ -1975,6 +2275,8 @@ static BLOCKS_BIRCH_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_FENCE_POOL0_ENTRIES,
@@ -1993,6 +2295,8 @@ static BLOCKS_BIRCH_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_FENCE_GATE_POOL0_ENTRIES,
@@ -2011,6 +2315,8 @@ static BLOCKS_BIRCH_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_HANGING_SIGN_POOL0_ENTRIES,
@@ -2030,6 +2336,8 @@ static BLOCKS_BIRCH_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:birch_sapling",
@@ -2046,6 +2354,8 @@ static BLOCKS_BIRCH_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_BIRCH_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -2057,6 +2367,8 @@ static BLOCKS_BIRCH_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_BIRCH_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -2084,6 +2396,8 @@ static BLOCKS_BIRCH_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_LOG_POOL0_ENTRIES,
@@ -2102,6 +2416,8 @@ static BLOCKS_BIRCH_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_PLANKS_POOL0_ENTRIES,
@@ -2120,6 +2436,8 @@ static BLOCKS_BIRCH_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -2138,6 +2456,8 @@ static BLOCKS_BIRCH_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_SAPLING_POOL0_ENTRIES,
@@ -2156,6 +2476,8 @@ static BLOCKS_BIRCH_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_SHELF_POOL0_ENTRIES,
@@ -2174,6 +2496,8 @@ static BLOCKS_BIRCH_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_SIGN_POOL0_ENTRIES,
@@ -2195,6 +2519,8 @@ static BLOCKS_BIRCH_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:birch_slab",
@@ -2205,6 +2531,8 @@ static BLOCKS_BIRCH_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BIRCH_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -2224,6 +2552,8 @@ static BLOCKS_BIRCH_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_STAIRS_POOL0_ENTRIES,
@@ -2242,6 +2572,8 @@ static BLOCKS_BIRCH_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_TRAPDOOR_POOL0_ENTRIES,
@@ -2260,6 +2592,8 @@ static BLOCKS_BIRCH_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BIRCH_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BIRCH_WOOD_POOL0_ENTRIES,
@@ -2278,6 +2612,8 @@ static BLOCKS_BLACK_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_BANNER_POOL0_ENTRIES,
@@ -2298,6 +2634,8 @@ static BLOCKS_BLACK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_BED_POOL0_ENTRIES,
@@ -2319,6 +2657,8 @@ static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:black_candle",
@@ -2334,6 +2674,8 @@ static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:black_candle",
@@ -2352,6 +2694,8 @@ static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:black_candle",
@@ -2370,6 +2714,8 @@ static BLOCKS_BLACK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BLACK_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -2389,6 +2735,8 @@ static BLOCKS_BLACK_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_CANDLE_CAKE_POOL0_ENTRIES,
@@ -2407,6 +2755,8 @@ static BLOCKS_BLACK_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_CARPET_POOL0_ENTRIES,
@@ -2425,6 +2775,8 @@ static BLOCKS_BLACK_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_CONCRETE_POOL0_ENTRIES,
@@ -2443,6 +2795,8 @@ static BLOCKS_BLACK_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -2461,6 +2815,8 @@ static BLOCKS_BLACK_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -2479,6 +2835,8 @@ static BLOCKS_BLACK_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_SHULKER_BOX_POOL0_ENTRIES,
@@ -2497,6 +2855,8 @@ static BLOCKS_BLACK_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_STAINED_GLASS_POOL0_ENTRIES,
@@ -2515,6 +2875,8 @@ static BLOCKS_BLACK_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -2533,6 +2895,8 @@ static BLOCKS_BLACK_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_TERRACOTTA_POOL0_ENTRIES,
@@ -2551,6 +2915,8 @@ static BLOCKS_BLACK_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACK_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACK_WOOL_POOL0_ENTRIES,
@@ -2569,6 +2935,8 @@ static BLOCKS_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACKSTONE_POOL0_ENTRIES,
@@ -2590,6 +2958,8 @@ static BLOCKS_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:blackstone_slab",
@@ -2600,6 +2970,8 @@ static BLOCKS_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BLACKSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -2619,6 +2991,8 @@ static BLOCKS_BLACKSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACKSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACKSTONE_STAIRS_POOL0_ENTRIES,
@@ -2637,6 +3011,8 @@ static BLOCKS_BLACKSTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLACKSTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLACKSTONE_WALL_POOL0_ENTRIES,
@@ -2655,6 +3031,8 @@ static BLOCKS_BLAST_FURNACE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLAST_FURNACE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLAST_FURNACE_POOL0_ENTRIES,
@@ -2673,6 +3051,8 @@ static BLOCKS_BLUE_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_BANNER_POOL0_ENTRIES,
@@ -2693,6 +3073,8 @@ static BLOCKS_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_BED_POOL0_ENTRIES,
@@ -2714,6 +3096,8 @@ static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:blue_candle",
@@ -2729,6 +3113,8 @@ static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:blue_candle",
@@ -2747,6 +3133,8 @@ static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:blue_candle",
@@ -2765,6 +3153,8 @@ static BLOCKS_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BLUE_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -2784,6 +3174,8 @@ static BLOCKS_BLUE_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_CANDLE_CAKE_POOL0_ENTRIES,
@@ -2802,6 +3194,8 @@ static BLOCKS_BLUE_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_CARPET_POOL0_ENTRIES,
@@ -2820,6 +3214,8 @@ static BLOCKS_BLUE_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_CONCRETE_POOL0_ENTRIES,
@@ -2838,6 +3234,8 @@ static BLOCKS_BLUE_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -2856,6 +3254,8 @@ static BLOCKS_BLUE_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -2874,6 +3274,8 @@ static BLOCKS_BLUE_ICE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_ICE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_ICE_POOL0_ENTRIES,
@@ -2892,6 +3294,8 @@ static BLOCKS_BLUE_ORCHID_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_ORCHID_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_ORCHID_POOL0_ENTRIES,
@@ -2910,6 +3314,8 @@ static BLOCKS_BLUE_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_SHULKER_BOX_POOL0_ENTRIES,
@@ -2928,6 +3334,8 @@ static BLOCKS_BLUE_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_STAINED_GLASS_POOL0_ENTRIES,
@@ -2946,6 +3354,8 @@ static BLOCKS_BLUE_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -2964,6 +3374,8 @@ static BLOCKS_BLUE_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_TERRACOTTA_POOL0_ENTRIES,
@@ -2982,6 +3394,8 @@ static BLOCKS_BLUE_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BLUE_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BLUE_WOOL_POOL0_ENTRIES,
@@ -3000,6 +3414,8 @@ static BLOCKS_BONE_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BONE_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BONE_BLOCK_POOL0_ENTRIES,
@@ -3019,6 +3435,8 @@ static BLOCKS_BOOKSHELF_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -3027,6 +3445,8 @@ static BLOCKS_BOOKSHELF_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BOOKSHELF_POOLS: &[LootPool] = &[LootPool {
@@ -3046,6 +3466,8 @@ static BLOCKS_BRAIN_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BRAIN_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRAIN_CORAL_POOL0_ENTRIES,
@@ -3065,6 +3487,8 @@ static BLOCKS_BRAIN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_brain_coral_block",
@@ -3076,6 +3500,8 @@ static BLOCKS_BRAIN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_BRAIN_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -3095,6 +3521,8 @@ static BLOCKS_BRAIN_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BRAIN_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRAIN_CORAL_FAN_POOL0_ENTRIES,
@@ -3113,6 +3541,8 @@ static BLOCKS_BREWING_STAND_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BREWING_STAND_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BREWING_STAND_POOL0_ENTRIES,
@@ -3134,6 +3564,8 @@ static BLOCKS_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:brick_slab",
@@ -3144,6 +3576,8 @@ static BLOCKS_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -3163,6 +3597,8 @@ static BLOCKS_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRICK_STAIRS_POOL0_ENTRIES,
@@ -3181,6 +3617,8 @@ static BLOCKS_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRICK_WALL_POOL0_ENTRIES,
@@ -3199,6 +3637,8 @@ static BLOCKS_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BRICKS_POOL0_ENTRIES,
@@ -3217,6 +3657,8 @@ static BLOCKS_BROWN_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_BANNER_POOL0_ENTRIES,
@@ -3237,6 +3679,8 @@ static BLOCKS_BROWN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_BED_POOL0_ENTRIES,
@@ -3258,6 +3702,8 @@ static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:brown_candle",
@@ -3273,6 +3719,8 @@ static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:brown_candle",
@@ -3291,6 +3739,8 @@ static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:brown_candle",
@@ -3309,6 +3759,8 @@ static BLOCKS_BROWN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BROWN_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -3328,6 +3780,8 @@ static BLOCKS_BROWN_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_CANDLE_CAKE_POOL0_ENTRIES,
@@ -3346,6 +3800,8 @@ static BLOCKS_BROWN_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_CARPET_POOL0_ENTRIES,
@@ -3364,6 +3820,8 @@ static BLOCKS_BROWN_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_CONCRETE_POOL0_ENTRIES,
@@ -3382,6 +3840,8 @@ static BLOCKS_BROWN_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -3400,6 +3860,8 @@ static BLOCKS_BROWN_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -3418,6 +3880,8 @@ static BLOCKS_BROWN_MUSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_MUSHROOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_MUSHROOM_POOL0_ENTRIES,
@@ -3437,6 +3901,8 @@ static BLOCKS_BROWN_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_mushroom",
@@ -3445,6 +3911,8 @@ static BLOCKS_BROWN_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: Some((0i32, 2147483647i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_BROWN_MUSHROOM_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -3464,6 +3932,8 @@ static BLOCKS_BROWN_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_SHULKER_BOX_POOL0_ENTRIES,
@@ -3482,6 +3952,8 @@ static BLOCKS_BROWN_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_STAINED_GLASS_POOL0_ENTRIES,
@@ -3500,6 +3972,8 @@ static BLOCKS_BROWN_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -3518,6 +3992,8 @@ static BLOCKS_BROWN_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_TERRACOTTA_POOL0_ENTRIES,
@@ -3536,6 +4012,8 @@ static BLOCKS_BROWN_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BROWN_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BROWN_WOOL_POOL0_ENTRIES,
@@ -3554,6 +4032,8 @@ static BLOCKS_BUBBLE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BUBBLE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BUBBLE_CORAL_POOL0_ENTRIES,
@@ -3573,6 +4053,8 @@ static BLOCKS_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_bubble_coral_block",
@@ -3584,6 +4066,8 @@ static BLOCKS_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_BUBBLE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -3603,6 +4087,8 @@ static BLOCKS_BUBBLE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BUBBLE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BUBBLE_CORAL_FAN_POOL0_ENTRIES,
@@ -3625,6 +4111,8 @@ static BLOCKS_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_BUSH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_BUSH_POOL0_ENTRIES,
@@ -3643,6 +4131,8 @@ static BLOCKS_CACTUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CACTUS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CACTUS_POOL0_ENTRIES,
@@ -3661,6 +4151,8 @@ static BLOCKS_CACTUS_FLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CACTUS_FLOWER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CACTUS_FLOWER_POOL0_ENTRIES,
@@ -3683,6 +4175,8 @@ static BLOCKS_CALCITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CALCITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CALCITE_POOL0_ENTRIES,
@@ -3701,6 +4195,8 @@ static BLOCKS_CALIBRATED_SCULK_SENSOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CALIBRATED_SCULK_SENSOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CALIBRATED_SCULK_SENSOR_POOL0_ENTRIES,
@@ -3720,6 +4216,8 @@ static BLOCKS_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:charcoal",
@@ -3731,6 +4229,8 @@ static BLOCKS_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_CAMPFIRE_POOLS: &[LootPool] = &[LootPool {
@@ -3753,6 +4253,8 @@ static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:candle",
@@ -3768,6 +4270,8 @@ static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:candle",
@@ -3786,6 +4290,8 @@ static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:candle",
@@ -3804,6 +4310,8 @@ static BLOCKS_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -3823,6 +4331,8 @@ static BLOCKS_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CANDLE_CAKE_POOL0_ENTRIES,
@@ -3841,6 +4351,8 @@ static BLOCKS_CARROTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_CARROTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:carrot",
@@ -3852,6 +4364,8 @@ static BLOCKS_CARROTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         extra: 3i32,
         probability: 0.5714286f32,
     }),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_CARROTS_POOLS: &[LootPool] = &[
     LootPool {
@@ -3881,6 +4395,8 @@ static BLOCKS_CARTOGRAPHY_TABLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CARTOGRAPHY_TABLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CARTOGRAPHY_TABLE_POOL0_ENTRIES,
@@ -3899,6 +4415,8 @@ static BLOCKS_CARVED_PUMPKIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CARVED_PUMPKIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CARVED_PUMPKIN_POOL0_ENTRIES,
@@ -3917,6 +4435,8 @@ static BLOCKS_CAULDRON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CAULDRON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CAULDRON_POOL0_ENTRIES,
@@ -3935,6 +4455,8 @@ static BLOCKS_CAVE_VINES_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CAVE_VINES_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CAVE_VINES_POOL0_ENTRIES,
@@ -3955,6 +4477,8 @@ static BLOCKS_CAVE_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CAVE_VINES_PLANT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CAVE_VINES_PLANT_POOL0_ENTRIES,
@@ -3975,6 +4499,8 @@ static BLOCKS_CHERRY_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_BUTTON_POOL0_ENTRIES,
@@ -3995,6 +4521,8 @@ static BLOCKS_CHERRY_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_DOOR_POOL0_ENTRIES,
@@ -4013,6 +4541,8 @@ static BLOCKS_CHERRY_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_FENCE_POOL0_ENTRIES,
@@ -4031,6 +4561,8 @@ static BLOCKS_CHERRY_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_FENCE_GATE_POOL0_ENTRIES,
@@ -4049,6 +4581,8 @@ static BLOCKS_CHERRY_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_HANGING_SIGN_POOL0_ENTRIES,
@@ -4068,6 +4602,8 @@ static BLOCKS_CHERRY_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cherry_sapling",
@@ -4084,6 +4620,8 @@ static BLOCKS_CHERRY_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_CHERRY_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -4095,6 +4633,8 @@ static BLOCKS_CHERRY_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_CHERRY_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -4122,6 +4662,8 @@ static BLOCKS_CHERRY_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_LOG_POOL0_ENTRIES,
@@ -4140,6 +4682,8 @@ static BLOCKS_CHERRY_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_PLANKS_POOL0_ENTRIES,
@@ -4158,6 +4702,8 @@ static BLOCKS_CHERRY_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -4176,6 +4722,8 @@ static BLOCKS_CHERRY_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_SAPLING_POOL0_ENTRIES,
@@ -4194,6 +4742,8 @@ static BLOCKS_CHERRY_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_SHELF_POOL0_ENTRIES,
@@ -4212,6 +4762,8 @@ static BLOCKS_CHERRY_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_SIGN_POOL0_ENTRIES,
@@ -4233,6 +4785,8 @@ static BLOCKS_CHERRY_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cherry_slab",
@@ -4243,6 +4797,8 @@ static BLOCKS_CHERRY_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CHERRY_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -4262,6 +4818,8 @@ static BLOCKS_CHERRY_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_STAIRS_POOL0_ENTRIES,
@@ -4280,6 +4838,8 @@ static BLOCKS_CHERRY_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_TRAPDOOR_POOL0_ENTRIES,
@@ -4298,6 +4858,8 @@ static BLOCKS_CHERRY_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHERRY_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHERRY_WOOD_POOL0_ENTRIES,
@@ -4316,6 +4878,8 @@ static BLOCKS_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHEST_POOL0_ENTRIES,
@@ -4334,6 +4898,8 @@ static BLOCKS_CHIPPED_ANVIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHIPPED_ANVIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHIPPED_ANVIL_POOL0_ENTRIES,
@@ -4352,6 +4918,8 @@ static BLOCKS_CHISELED_BOOKSHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_BOOKSHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_BOOKSHELF_POOL0_ENTRIES,
@@ -4370,6 +4938,8 @@ static BLOCKS_CHISELED_CINNABAR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_CINNABAR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_CINNABAR_POOL0_ENTRIES,
@@ -4388,6 +4958,8 @@ static BLOCKS_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_COPPER_POOL0_ENTRIES,
@@ -4406,6 +4978,8 @@ static BLOCKS_CHISELED_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_DEEPSLATE_POOL0_ENTRIES,
@@ -4424,6 +4998,8 @@ static BLOCKS_CHISELED_NETHER_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_NETHER_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_NETHER_BRICKS_POOL0_ENTRIES,
@@ -4442,6 +5018,8 @@ static BLOCKS_CHISELED_POLISHED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_POLISHED_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_POLISHED_BLACKSTONE_POOL0_ENTRIES,
@@ -4460,6 +5038,8 @@ static BLOCKS_CHISELED_QUARTZ_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_QUARTZ_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_QUARTZ_BLOCK_POOL0_ENTRIES,
@@ -4478,6 +5058,8 @@ static BLOCKS_CHISELED_RED_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_RED_SANDSTONE_POOL0_ENTRIES,
@@ -4496,6 +5078,8 @@ static BLOCKS_CHISELED_RESIN_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_RESIN_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_RESIN_BRICKS_POOL0_ENTRIES,
@@ -4514,6 +5098,8 @@ static BLOCKS_CHISELED_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_SANDSTONE_POOL0_ENTRIES,
@@ -4532,6 +5118,8 @@ static BLOCKS_CHISELED_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_STONE_BRICKS_POOL0_ENTRIES,
@@ -4550,6 +5138,8 @@ static BLOCKS_CHISELED_SULFUR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_SULFUR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_SULFUR_POOL0_ENTRIES,
@@ -4568,6 +5158,8 @@ static BLOCKS_CHISELED_TUFF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_TUFF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_TUFF_POOL0_ENTRIES,
@@ -4586,6 +5178,8 @@ static BLOCKS_CHISELED_TUFF_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHISELED_TUFF_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHISELED_TUFF_BRICKS_POOL0_ENTRIES,
@@ -4604,6 +5198,8 @@ static BLOCKS_CHORUS_FLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::SurvivesExplosion,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CHORUS_FLOWER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHORUS_FLOWER_POOL0_ENTRIES,
@@ -4622,6 +5218,8 @@ static BLOCKS_CHORUS_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_CHORUS_PLANT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CHORUS_PLANT_POOL0_ENTRIES,
@@ -4640,6 +5238,8 @@ static BLOCKS_CINNABAR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_POOL0_ENTRIES,
@@ -4661,6 +5261,8 @@ static BLOCKS_CINNABAR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cinnabar_brick_slab",
@@ -4671,6 +5273,8 @@ static BLOCKS_CINNABAR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CINNABAR_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -4690,6 +5294,8 @@ static BLOCKS_CINNABAR_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_BRICK_STAIRS_POOL0_ENTRIES,
@@ -4708,6 +5314,8 @@ static BLOCKS_CINNABAR_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_BRICK_WALL_POOL0_ENTRIES,
@@ -4726,6 +5334,8 @@ static BLOCKS_CINNABAR_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_BRICKS_POOL0_ENTRIES,
@@ -4747,6 +5357,8 @@ static BLOCKS_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cinnabar_slab",
@@ -4757,6 +5369,8 @@ static BLOCKS_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CINNABAR_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -4776,6 +5390,8 @@ static BLOCKS_CINNABAR_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_STAIRS_POOL0_ENTRIES,
@@ -4794,6 +5410,8 @@ static BLOCKS_CINNABAR_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CINNABAR_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CINNABAR_WALL_POOL0_ENTRIES,
@@ -4813,6 +5431,8 @@ static BLOCKS_CLAY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:clay_ball",
@@ -4821,6 +5441,8 @@ static BLOCKS_CLAY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CLAY_POOLS: &[LootPool] = &[LootPool {
@@ -4840,6 +5462,8 @@ static BLOCKS_CLOSED_EYEBLOSSOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CLOSED_EYEBLOSSOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CLOSED_EYEBLOSSOM_POOL0_ENTRIES,
@@ -4858,6 +5482,8 @@ static BLOCKS_COAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COAL_BLOCK_POOL0_ENTRIES,
@@ -4877,6 +5503,8 @@ static BLOCKS_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -4885,6 +5513,8 @@ static BLOCKS_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_COAL_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -4904,6 +5534,8 @@ static BLOCKS_COARSE_DIRT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COARSE_DIRT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COARSE_DIRT_POOL0_ENTRIES,
@@ -4922,6 +5554,8 @@ static BLOCKS_COBBLED_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLED_DEEPSLATE_POOL0_ENTRIES,
@@ -4943,6 +5577,8 @@ static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cobbled_deepslate_slab",
@@ -4953,6 +5589,8 @@ static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_COBBLED_DEEPSLATE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -4972,6 +5610,8 @@ static BLOCKS_COBBLED_DEEPSLATE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLED_DEEPSLATE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLED_DEEPSLATE_STAIRS_POOL0_ENTRIES,
@@ -4990,6 +5630,8 @@ static BLOCKS_COBBLED_DEEPSLATE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLED_DEEPSLATE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLED_DEEPSLATE_WALL_POOL0_ENTRIES,
@@ -5008,6 +5650,8 @@ static BLOCKS_COBBLESTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLESTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLESTONE_POOL0_ENTRIES,
@@ -5029,6 +5673,8 @@ static BLOCKS_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cobblestone_slab",
@@ -5039,6 +5685,8 @@ static BLOCKS_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_COBBLESTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -5058,6 +5706,8 @@ static BLOCKS_COBBLESTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLESTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLESTONE_STAIRS_POOL0_ENTRIES,
@@ -5076,6 +5726,8 @@ static BLOCKS_COBBLESTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COBBLESTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COBBLESTONE_WALL_POOL0_ENTRIES,
@@ -5095,6 +5747,8 @@ static BLOCKS_COBWEB_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -5106,6 +5760,8 @@ static BLOCKS_COBWEB_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_COBWEB_POOLS: &[LootPool] = &[LootPool {
@@ -5128,6 +5784,8 @@ static BLOCKS_COCOA_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "2")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cocoa_beans",
@@ -5138,6 +5796,8 @@ static BLOCKS_COCOA_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "2")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_COCOA_POOLS: &[LootPool] = &[LootPool {
@@ -5157,6 +5817,8 @@ static BLOCKS_COMPARATOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COMPARATOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COMPARATOR_POOL0_ENTRIES,
@@ -5175,6 +5837,8 @@ static BLOCKS_COMPOSTER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_COMPOSTER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone_meal",
@@ -5183,6 +5847,8 @@ static BLOCKS_COMPOSTER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COMPOSTER_POOLS: &[LootPool] = &[
     LootPool {
@@ -5212,6 +5878,8 @@ static BLOCKS_CONDUIT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CONDUIT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CONDUIT_POOL0_ENTRIES,
@@ -5230,6 +5898,8 @@ static BLOCKS_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_BARS_POOL0_ENTRIES,
@@ -5248,6 +5918,8 @@ static BLOCKS_COPPER_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_BLOCK_POOL0_ENTRIES,
@@ -5266,6 +5938,8 @@ static BLOCKS_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_BULB_POOL0_ENTRIES,
@@ -5284,6 +5958,8 @@ static BLOCKS_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_CHAIN_POOL0_ENTRIES,
@@ -5302,6 +5978,8 @@ static BLOCKS_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_CHEST_POOL0_ENTRIES,
@@ -5322,6 +6000,8 @@ static BLOCKS_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_DOOR_POOL0_ENTRIES,
@@ -5340,6 +6020,8 @@ static BLOCKS_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -5358,6 +6040,8 @@ static BLOCKS_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_GRATE_POOL0_ENTRIES,
@@ -5376,6 +6060,8 @@ static BLOCKS_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_LANTERN_POOL0_ENTRIES,
@@ -5395,6 +6081,8 @@ static BLOCKS_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_copper",
@@ -5403,6 +6091,8 @@ static BLOCKS_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_COPPER_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -5422,6 +6112,8 @@ static BLOCKS_COPPER_TORCH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_TORCH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_TORCH_POOL0_ENTRIES,
@@ -5440,6 +6132,8 @@ static BLOCKS_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -5458,6 +6152,8 @@ static BLOCKS_CORNFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CORNFLOWER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CORNFLOWER_POOL0_ENTRIES,
@@ -5476,6 +6172,8 @@ static BLOCKS_CRACKED_DEEPSLATE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRACKED_DEEPSLATE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRACKED_DEEPSLATE_BRICKS_POOL0_ENTRIES,
@@ -5494,6 +6192,8 @@ static BLOCKS_CRACKED_DEEPSLATE_TILES_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRACKED_DEEPSLATE_TILES_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRACKED_DEEPSLATE_TILES_POOL0_ENTRIES,
@@ -5512,6 +6212,8 @@ static BLOCKS_CRACKED_NETHER_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRACKED_NETHER_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRACKED_NETHER_BRICKS_POOL0_ENTRIES,
@@ -5530,6 +6232,8 @@ static BLOCKS_CRACKED_POLISHED_BLACKSTONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRACKED_POLISHED_BLACKSTONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRACKED_POLISHED_BLACKSTONE_BRICKS_POOL0_ENTRIES,
@@ -5548,6 +6252,8 @@ static BLOCKS_CRACKED_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRACKED_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRACKED_STONE_BRICKS_POOL0_ENTRIES,
@@ -5566,6 +6272,8 @@ static BLOCKS_CRAFTER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRAFTER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRAFTER_POOL0_ENTRIES,
@@ -5584,6 +6292,8 @@ static BLOCKS_CRAFTING_TABLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRAFTING_TABLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRAFTING_TABLE_POOL0_ENTRIES,
@@ -5603,6 +6313,8 @@ static BLOCKS_CREAKING_HEART_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:resin_clump",
@@ -5611,6 +6323,8 @@ static BLOCKS_CREAKING_HEART_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: Some((0i32, 9i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CREAKING_HEART_POOLS: &[LootPool] = &[LootPool {
@@ -5630,6 +6344,8 @@ static BLOCKS_CREEPER_HEAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CREEPER_HEAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CREEPER_HEAD_POOL0_ENTRIES,
@@ -5648,6 +6364,8 @@ static BLOCKS_CRIMSON_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_BUTTON_POOL0_ENTRIES,
@@ -5668,6 +6386,8 @@ static BLOCKS_CRIMSON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_DOOR_POOL0_ENTRIES,
@@ -5686,6 +6406,8 @@ static BLOCKS_CRIMSON_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_FENCE_POOL0_ENTRIES,
@@ -5704,6 +6426,8 @@ static BLOCKS_CRIMSON_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_FENCE_GATE_POOL0_ENTRIES,
@@ -5722,6 +6446,8 @@ static BLOCKS_CRIMSON_FUNGUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_FUNGUS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_FUNGUS_POOL0_ENTRIES,
@@ -5740,6 +6466,8 @@ static BLOCKS_CRIMSON_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_HANGING_SIGN_POOL0_ENTRIES,
@@ -5758,6 +6486,8 @@ static BLOCKS_CRIMSON_HYPHAE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_HYPHAE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_HYPHAE_POOL0_ENTRIES,
@@ -5777,6 +6507,8 @@ static BLOCKS_CRIMSON_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:netherrack",
@@ -5788,6 +6520,8 @@ static BLOCKS_CRIMSON_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_CRIMSON_NYLIUM_POOLS: &[LootPool] = &[LootPool {
@@ -5807,6 +6541,8 @@ static BLOCKS_CRIMSON_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_PLANKS_POOL0_ENTRIES,
@@ -5825,6 +6561,8 @@ static BLOCKS_CRIMSON_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -5843,6 +6581,8 @@ static BLOCKS_CRIMSON_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_ROOTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_ROOTS_POOL0_ENTRIES,
@@ -5861,6 +6601,8 @@ static BLOCKS_CRIMSON_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_SHELF_POOL0_ENTRIES,
@@ -5879,6 +6621,8 @@ static BLOCKS_CRIMSON_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_SIGN_POOL0_ENTRIES,
@@ -5900,6 +6644,8 @@ static BLOCKS_CRIMSON_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:crimson_slab",
@@ -5910,6 +6656,8 @@ static BLOCKS_CRIMSON_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CRIMSON_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -5929,6 +6677,8 @@ static BLOCKS_CRIMSON_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_STAIRS_POOL0_ENTRIES,
@@ -5947,6 +6697,8 @@ static BLOCKS_CRIMSON_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_STEM_POOL0_ENTRIES,
@@ -5965,6 +6717,8 @@ static BLOCKS_CRIMSON_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRIMSON_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRIMSON_TRAPDOOR_POOL0_ENTRIES,
@@ -5983,6 +6737,8 @@ static BLOCKS_CRYING_OBSIDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CRYING_OBSIDIAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CRYING_OBSIDIAN_POOL0_ENTRIES,
@@ -6001,6 +6757,8 @@ static BLOCKS_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_COPPER_POOL0_ENTRIES,
@@ -6022,6 +6780,8 @@ static BLOCKS_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cut_copper_slab",
@@ -6032,6 +6792,8 @@ static BLOCKS_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -6051,6 +6813,8 @@ static BLOCKS_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -6069,6 +6833,8 @@ static BLOCKS_CUT_RED_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CUT_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_RED_SANDSTONE_POOL0_ENTRIES,
@@ -6090,6 +6856,8 @@ static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cut_red_sandstone_slab",
@@ -6100,6 +6868,8 @@ static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CUT_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -6119,6 +6889,8 @@ static BLOCKS_CUT_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CUT_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CUT_SANDSTONE_POOL0_ENTRIES,
@@ -6140,6 +6912,8 @@ static BLOCKS_CUT_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cut_sandstone_slab",
@@ -6150,6 +6924,8 @@ static BLOCKS_CUT_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CUT_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -6169,6 +6945,8 @@ static BLOCKS_CYAN_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_BANNER_POOL0_ENTRIES,
@@ -6189,6 +6967,8 @@ static BLOCKS_CYAN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_BED_POOL0_ENTRIES,
@@ -6210,6 +6990,8 @@ static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cyan_candle",
@@ -6225,6 +7007,8 @@ static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cyan_candle",
@@ -6243,6 +7027,8 @@ static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:cyan_candle",
@@ -6261,6 +7047,8 @@ static BLOCKS_CYAN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_CYAN_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -6280,6 +7068,8 @@ static BLOCKS_CYAN_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_CANDLE_CAKE_POOL0_ENTRIES,
@@ -6298,6 +7088,8 @@ static BLOCKS_CYAN_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_CARPET_POOL0_ENTRIES,
@@ -6316,6 +7108,8 @@ static BLOCKS_CYAN_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_CONCRETE_POOL0_ENTRIES,
@@ -6334,6 +7128,8 @@ static BLOCKS_CYAN_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -6352,6 +7148,8 @@ static BLOCKS_CYAN_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -6370,6 +7168,8 @@ static BLOCKS_CYAN_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_SHULKER_BOX_POOL0_ENTRIES,
@@ -6388,6 +7188,8 @@ static BLOCKS_CYAN_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_STAINED_GLASS_POOL0_ENTRIES,
@@ -6406,6 +7208,8 @@ static BLOCKS_CYAN_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -6424,6 +7228,8 @@ static BLOCKS_CYAN_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_TERRACOTTA_POOL0_ENTRIES,
@@ -6442,6 +7248,8 @@ static BLOCKS_CYAN_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_CYAN_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_CYAN_WOOL_POOL0_ENTRIES,
@@ -6460,6 +7268,8 @@ static BLOCKS_DAMAGED_ANVIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DAMAGED_ANVIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DAMAGED_ANVIL_POOL0_ENTRIES,
@@ -6478,6 +7288,8 @@ static BLOCKS_DANDELION_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DANDELION_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DANDELION_POOL0_ENTRIES,
@@ -6496,6 +7308,8 @@ static BLOCKS_DARK_OAK_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_BUTTON_POOL0_ENTRIES,
@@ -6516,6 +7330,8 @@ static BLOCKS_DARK_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_DOOR_POOL0_ENTRIES,
@@ -6534,6 +7350,8 @@ static BLOCKS_DARK_OAK_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_FENCE_POOL0_ENTRIES,
@@ -6552,6 +7370,8 @@ static BLOCKS_DARK_OAK_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_FENCE_GATE_POOL0_ENTRIES,
@@ -6570,6 +7390,8 @@ static BLOCKS_DARK_OAK_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_HANGING_SIGN_POOL0_ENTRIES,
@@ -6589,6 +7411,8 @@ static BLOCKS_DARK_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dark_oak_sapling",
@@ -6605,6 +7429,8 @@ static BLOCKS_DARK_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_DARK_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -6616,6 +7442,8 @@ static BLOCKS_DARK_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_DARK_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:apple",
@@ -6635,6 +7463,8 @@ static BLOCKS_DARK_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
         },
     ]),
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -6669,6 +7499,8 @@ static BLOCKS_DARK_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_LOG_POOL0_ENTRIES,
@@ -6687,6 +7519,8 @@ static BLOCKS_DARK_OAK_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_PLANKS_POOL0_ENTRIES,
@@ -6705,6 +7539,8 @@ static BLOCKS_DARK_OAK_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -6723,6 +7559,8 @@ static BLOCKS_DARK_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_SAPLING_POOL0_ENTRIES,
@@ -6741,6 +7579,8 @@ static BLOCKS_DARK_OAK_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_SHELF_POOL0_ENTRIES,
@@ -6759,6 +7599,8 @@ static BLOCKS_DARK_OAK_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_SIGN_POOL0_ENTRIES,
@@ -6780,6 +7622,8 @@ static BLOCKS_DARK_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:dark_oak_slab",
@@ -6790,6 +7634,8 @@ static BLOCKS_DARK_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DARK_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -6809,6 +7655,8 @@ static BLOCKS_DARK_OAK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_STAIRS_POOL0_ENTRIES,
@@ -6827,6 +7675,8 @@ static BLOCKS_DARK_OAK_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_TRAPDOOR_POOL0_ENTRIES,
@@ -6845,6 +7695,8 @@ static BLOCKS_DARK_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_OAK_WOOD_POOL0_ENTRIES,
@@ -6863,6 +7715,8 @@ static BLOCKS_DARK_PRISMARINE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_PRISMARINE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_PRISMARINE_POOL0_ENTRIES,
@@ -6884,6 +7738,8 @@ static BLOCKS_DARK_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:dark_prismarine_slab",
@@ -6894,6 +7750,8 @@ static BLOCKS_DARK_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DARK_PRISMARINE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -6913,6 +7771,8 @@ static BLOCKS_DARK_PRISMARINE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DARK_PRISMARINE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DARK_PRISMARINE_STAIRS_POOL0_ENTRIES,
@@ -6931,6 +7791,8 @@ static BLOCKS_DAYLIGHT_DETECTOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DAYLIGHT_DETECTOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DAYLIGHT_DETECTOR_POOL0_ENTRIES,
@@ -6949,6 +7811,8 @@ static BLOCKS_DEAD_BRAIN_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BRAIN_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BRAIN_CORAL_POOL0_ENTRIES,
@@ -6967,6 +7831,8 @@ static BLOCKS_DEAD_BRAIN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BRAIN_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BRAIN_CORAL_BLOCK_POOL0_ENTRIES,
@@ -6985,6 +7851,8 @@ static BLOCKS_DEAD_BRAIN_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BRAIN_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BRAIN_CORAL_FAN_POOL0_ENTRIES,
@@ -7003,6 +7871,8 @@ static BLOCKS_DEAD_BUBBLE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BUBBLE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BUBBLE_CORAL_POOL0_ENTRIES,
@@ -7021,6 +7891,8 @@ static BLOCKS_DEAD_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BUBBLE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES,
@@ -7039,6 +7911,8 @@ static BLOCKS_DEAD_BUBBLE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_BUBBLE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_BUBBLE_CORAL_FAN_POOL0_ENTRIES,
@@ -7058,6 +7932,8 @@ static BLOCKS_DEAD_BUSH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -7066,6 +7942,8 @@ static BLOCKS_DEAD_BUSH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::Inverted(&LootCondition::Shears),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEAD_BUSH_POOLS: &[LootPool] = &[LootPool {
@@ -7085,6 +7963,8 @@ static BLOCKS_DEAD_FIRE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_FIRE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_FIRE_CORAL_POOL0_ENTRIES,
@@ -7103,6 +7983,8 @@ static BLOCKS_DEAD_FIRE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_FIRE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_FIRE_CORAL_BLOCK_POOL0_ENTRIES,
@@ -7121,6 +8003,8 @@ static BLOCKS_DEAD_FIRE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_FIRE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_FIRE_CORAL_FAN_POOL0_ENTRIES,
@@ -7139,6 +8023,8 @@ static BLOCKS_DEAD_HORN_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_HORN_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_HORN_CORAL_POOL0_ENTRIES,
@@ -7157,6 +8043,8 @@ static BLOCKS_DEAD_HORN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_HORN_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_HORN_CORAL_BLOCK_POOL0_ENTRIES,
@@ -7175,6 +8063,8 @@ static BLOCKS_DEAD_HORN_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_HORN_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_HORN_CORAL_FAN_POOL0_ENTRIES,
@@ -7193,6 +8083,8 @@ static BLOCKS_DEAD_TUBE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_TUBE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_TUBE_CORAL_POOL0_ENTRIES,
@@ -7211,6 +8103,8 @@ static BLOCKS_DEAD_TUBE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_TUBE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_TUBE_CORAL_BLOCK_POOL0_ENTRIES,
@@ -7229,6 +8123,8 @@ static BLOCKS_DEAD_TUBE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEAD_TUBE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEAD_TUBE_CORAL_FAN_POOL0_ENTRIES,
@@ -7249,6 +8145,8 @@ static BLOCKS_DECORATED_POT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("cracked", "true")],
     }),
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DECORATED_POT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DECORATED_POT_POOL0_ENTRIES,
@@ -7268,6 +8166,8 @@ static BLOCKS_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cobbled_deepslate",
@@ -7279,6 +8179,8 @@ static BLOCKS_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
@@ -7301,6 +8203,8 @@ static BLOCKS_DEEPSLATE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:deepslate_brick_slab",
@@ -7311,6 +8215,8 @@ static BLOCKS_DEEPSLATE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -7330,6 +8236,8 @@ static BLOCKS_DEEPSLATE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -7348,6 +8256,8 @@ static BLOCKS_DEEPSLATE_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_BRICK_WALL_POOL0_ENTRIES,
@@ -7366,6 +8276,8 @@ static BLOCKS_DEEPSLATE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_BRICKS_POOL0_ENTRIES,
@@ -7385,6 +8297,8 @@ static BLOCKS_DEEPSLATE_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -7393,6 +8307,8 @@ static BLOCKS_DEEPSLATE_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_COAL_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7413,6 +8329,8 @@ static BLOCKS_DEEPSLATE_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_copper",
@@ -7421,6 +8339,8 @@ static BLOCKS_DEEPSLATE_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_COPPER_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7441,6 +8361,8 @@ static BLOCKS_DEEPSLATE_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -7449,6 +8371,8 @@ static BLOCKS_DEEPSLATE_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_DIAMOND_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7469,6 +8393,8 @@ static BLOCKS_DEEPSLATE_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -7477,6 +8403,8 @@ static BLOCKS_DEEPSLATE_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_EMERALD_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7497,6 +8425,8 @@ static BLOCKS_DEEPSLATE_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_gold",
@@ -7505,6 +8435,8 @@ static BLOCKS_DEEPSLATE_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_GOLD_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7525,6 +8457,8 @@ static BLOCKS_DEEPSLATE_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_iron",
@@ -7533,6 +8467,8 @@ static BLOCKS_DEEPSLATE_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_IRON_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7553,6 +8489,8 @@ static BLOCKS_DEEPSLATE_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -7561,6 +8499,8 @@ static BLOCKS_DEEPSLATE_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_LAPIS_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7581,6 +8521,8 @@ static BLOCKS_DEEPSLATE_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -7589,6 +8531,8 @@ static BLOCKS_DEEPSLATE_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_REDSTONE_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7611,6 +8555,8 @@ static BLOCKS_DEEPSLATE_TILE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:deepslate_tile_slab",
@@ -7621,6 +8567,8 @@ static BLOCKS_DEEPSLATE_TILE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DEEPSLATE_TILE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -7640,6 +8588,8 @@ static BLOCKS_DEEPSLATE_TILE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_TILE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_TILE_STAIRS_POOL0_ENTRIES,
@@ -7658,6 +8608,8 @@ static BLOCKS_DEEPSLATE_TILE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_TILE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_TILE_WALL_POOL0_ENTRIES,
@@ -7676,6 +8628,8 @@ static BLOCKS_DEEPSLATE_TILES_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DEEPSLATE_TILES_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DEEPSLATE_TILES_POOL0_ENTRIES,
@@ -7694,6 +8648,8 @@ static BLOCKS_DETECTOR_RAIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DETECTOR_RAIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DETECTOR_RAIL_POOL0_ENTRIES,
@@ -7712,6 +8668,8 @@ static BLOCKS_DIAMOND_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIAMOND_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIAMOND_BLOCK_POOL0_ENTRIES,
@@ -7731,6 +8689,8 @@ static BLOCKS_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -7739,6 +8699,8 @@ static BLOCKS_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DIAMOND_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -7758,6 +8720,8 @@ static BLOCKS_DIORITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIORITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIORITE_POOL0_ENTRIES,
@@ -7779,6 +8743,8 @@ static BLOCKS_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:diorite_slab",
@@ -7789,6 +8755,8 @@ static BLOCKS_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_DIORITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -7808,6 +8776,8 @@ static BLOCKS_DIORITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIORITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIORITE_STAIRS_POOL0_ENTRIES,
@@ -7826,6 +8796,8 @@ static BLOCKS_DIORITE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIORITE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIORITE_WALL_POOL0_ENTRIES,
@@ -7844,6 +8816,8 @@ static BLOCKS_DIRT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIRT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIRT_POOL0_ENTRIES,
@@ -7862,6 +8836,8 @@ static BLOCKS_DIRT_PATH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DIRT_PATH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DIRT_PATH_POOL0_ENTRIES,
@@ -7880,6 +8856,8 @@ static BLOCKS_DISPENSER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DISPENSER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DISPENSER_POOL0_ENTRIES,
@@ -7898,6 +8876,8 @@ static BLOCKS_DRAGON_EGG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DRAGON_EGG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DRAGON_EGG_POOL0_ENTRIES,
@@ -7916,6 +8896,8 @@ static BLOCKS_DRAGON_HEAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DRAGON_HEAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DRAGON_HEAD_POOL0_ENTRIES,
@@ -7934,6 +8916,8 @@ static BLOCKS_DRIED_GHAST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DRIED_GHAST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DRIED_GHAST_POOL0_ENTRIES,
@@ -7952,6 +8936,8 @@ static BLOCKS_DRIED_KELP_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DRIED_KELP_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DRIED_KELP_BLOCK_POOL0_ENTRIES,
@@ -7970,6 +8956,8 @@ static BLOCKS_DRIPSTONE_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DRIPSTONE_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DRIPSTONE_BLOCK_POOL0_ENTRIES,
@@ -7988,6 +8976,8 @@ static BLOCKS_DROPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_DROPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_DROPPER_POOL0_ENTRIES,
@@ -8006,6 +8996,8 @@ static BLOCKS_EMERALD_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EMERALD_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EMERALD_BLOCK_POOL0_ENTRIES,
@@ -8025,6 +9017,8 @@ static BLOCKS_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -8033,6 +9027,8 @@ static BLOCKS_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_EMERALD_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -8052,6 +9048,8 @@ static BLOCKS_ENCHANTING_TABLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ENCHANTING_TABLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ENCHANTING_TABLE_POOL0_ENTRIES,
@@ -8070,6 +9068,8 @@ static BLOCKS_END_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_END_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_ROD_POOL0_ENTRIES,
@@ -8088,6 +9088,8 @@ static BLOCKS_END_STONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_END_STONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_STONE_POOL0_ENTRIES,
@@ -8109,6 +9111,8 @@ static BLOCKS_END_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:end_stone_brick_slab",
@@ -8119,6 +9123,8 @@ static BLOCKS_END_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_END_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -8138,6 +9144,8 @@ static BLOCKS_END_STONE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_END_STONE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_STONE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -8156,6 +9164,8 @@ static BLOCKS_END_STONE_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_END_STONE_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_STONE_BRICK_WALL_POOL0_ENTRIES,
@@ -8174,6 +9184,8 @@ static BLOCKS_END_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_END_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_END_STONE_BRICKS_POOL0_ENTRIES,
@@ -8193,6 +9205,8 @@ static BLOCKS_ENDER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:obsidian",
@@ -8201,6 +9215,8 @@ static BLOCKS_ENDER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_ENDER_CHEST_POOLS: &[LootPool] = &[LootPool {
@@ -8220,6 +9236,8 @@ static BLOCKS_EXPOSED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -8238,6 +9256,8 @@ static BLOCKS_EXPOSED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_POOL0_ENTRIES,
@@ -8256,6 +9276,8 @@ static BLOCKS_EXPOSED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_BARS_POOL0_ENTRIES,
@@ -8274,6 +9296,8 @@ static BLOCKS_EXPOSED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_BULB_POOL0_ENTRIES,
@@ -8292,6 +9316,8 @@ static BLOCKS_EXPOSED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -8310,6 +9336,8 @@ static BLOCKS_EXPOSED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_CHEST_POOL0_ENTRIES,
@@ -8330,6 +9358,8 @@ static BLOCKS_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_DOOR_POOL0_ENTRIES,
@@ -8348,6 +9378,8 @@ static BLOCKS_EXPOSED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -8366,6 +9398,8 @@ static BLOCKS_EXPOSED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_GRATE_POOL0_ENTRIES,
@@ -8384,6 +9418,8 @@ static BLOCKS_EXPOSED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -8402,6 +9438,8 @@ static BLOCKS_EXPOSED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -8420,6 +9458,8 @@ static BLOCKS_EXPOSED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_CUT_COPPER_POOL0_ENTRIES,
@@ -8441,6 +9481,8 @@ static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:exposed_cut_copper_slab",
@@ -8451,6 +9493,8 @@ static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_EXPOSED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -8470,6 +9514,8 @@ static BLOCKS_EXPOSED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -8488,6 +9534,8 @@ static BLOCKS_EXPOSED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_EXPOSED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_EXPOSED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -8506,6 +9554,8 @@ static BLOCKS_FARMLAND_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FARMLAND_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FARMLAND_POOL0_ENTRIES,
@@ -8525,6 +9575,8 @@ static BLOCKS_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -8536,6 +9588,8 @@ static BLOCKS_FERN_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::RandomChance { chance: 0.125f32 },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_FERN_POOLS: &[LootPool] = &[LootPool {
@@ -8559,6 +9613,8 @@ static BLOCKS_FIRE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FIRE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FIRE_CORAL_POOL0_ENTRIES,
@@ -8578,6 +9634,8 @@ static BLOCKS_FIRE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_fire_coral_block",
@@ -8589,6 +9647,8 @@ static BLOCKS_FIRE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_FIRE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -8608,6 +9668,8 @@ static BLOCKS_FIRE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FIRE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FIRE_CORAL_FAN_POOL0_ENTRIES,
@@ -8626,6 +9688,8 @@ static BLOCKS_FIREFLY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FIREFLY_BUSH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FIREFLY_BUSH_POOL0_ENTRIES,
@@ -8644,6 +9708,8 @@ static BLOCKS_FLETCHING_TABLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FLETCHING_TABLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FLETCHING_TABLE_POOL0_ENTRIES,
@@ -8662,6 +9728,8 @@ static BLOCKS_FLOWER_POT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FLOWER_POT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FLOWER_POT_POOL0_ENTRIES,
@@ -8680,6 +9748,8 @@ static BLOCKS_FLOWERING_AZALEA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FLOWERING_AZALEA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FLOWERING_AZALEA_POOL0_ENTRIES,
@@ -8699,6 +9769,8 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flowering_azalea",
@@ -8715,6 +9787,8 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -8726,6 +9800,8 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_FLOWERING_AZALEA_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -8761,6 +9837,8 @@ static BLOCKS_FURNACE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_FURNACE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_FURNACE_POOL0_ENTRIES,
@@ -8780,6 +9858,8 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -8793,6 +9873,8 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gilded_blackstone",
@@ -8804,6 +9886,8 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_GILDED_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
@@ -8823,6 +9907,8 @@ static BLOCKS_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GLASS_POOL0_ENTRIES,
@@ -8841,6 +9927,8 @@ static BLOCKS_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GLASS_PANE_POOL0_ENTRIES,
@@ -8859,6 +9947,8 @@ static BLOCKS_GLOW_LICHEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: -1i32,
     condition: LootCondition::Shears,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_GLOW_LICHEN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GLOW_LICHEN_POOL0_ENTRIES,
@@ -8878,6 +9968,8 @@ static BLOCKS_GLOWSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glowstone_dust",
@@ -8886,6 +9978,8 @@ static BLOCKS_GLOWSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: Some((1i32, 4i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_GLOWSTONE_POOLS: &[LootPool] = &[LootPool {
@@ -8905,6 +9999,8 @@ static BLOCKS_GOLD_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GOLD_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GOLD_BLOCK_POOL0_ENTRIES,
@@ -8924,6 +10020,8 @@ static BLOCKS_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_gold",
@@ -8932,6 +10030,8 @@ static BLOCKS_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_GOLD_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -8951,6 +10051,8 @@ static BLOCKS_GOLDEN_DANDELION_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GOLDEN_DANDELION_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GOLDEN_DANDELION_POOL0_ENTRIES,
@@ -8969,6 +10071,8 @@ static BLOCKS_GRANITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRANITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRANITE_POOL0_ENTRIES,
@@ -8990,6 +10094,8 @@ static BLOCKS_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:granite_slab",
@@ -9000,6 +10106,8 @@ static BLOCKS_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_GRANITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -9019,6 +10127,8 @@ static BLOCKS_GRANITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRANITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRANITE_STAIRS_POOL0_ENTRIES,
@@ -9037,6 +10147,8 @@ static BLOCKS_GRANITE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRANITE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRANITE_WALL_POOL0_ENTRIES,
@@ -9056,6 +10168,8 @@ static BLOCKS_GRASS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dirt",
@@ -9067,6 +10181,8 @@ static BLOCKS_GRASS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_GRASS_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -9087,6 +10203,8 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flint",
@@ -9100,6 +10218,8 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gravel",
@@ -9111,6 +10231,8 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_GRAVEL_POOLS: &[LootPool] = &[LootPool {
@@ -9130,6 +10252,8 @@ static BLOCKS_GRAY_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_BANNER_POOL0_ENTRIES,
@@ -9150,6 +10274,8 @@ static BLOCKS_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_BED_POOL0_ENTRIES,
@@ -9171,6 +10297,8 @@ static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:gray_candle",
@@ -9186,6 +10314,8 @@ static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:gray_candle",
@@ -9204,6 +10334,8 @@ static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:gray_candle",
@@ -9222,6 +10354,8 @@ static BLOCKS_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_GRAY_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -9241,6 +10375,8 @@ static BLOCKS_GRAY_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_CANDLE_CAKE_POOL0_ENTRIES,
@@ -9259,6 +10395,8 @@ static BLOCKS_GRAY_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_CARPET_POOL0_ENTRIES,
@@ -9277,6 +10415,8 @@ static BLOCKS_GRAY_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_CONCRETE_POOL0_ENTRIES,
@@ -9295,6 +10435,8 @@ static BLOCKS_GRAY_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -9313,6 +10455,8 @@ static BLOCKS_GRAY_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -9331,6 +10475,8 @@ static BLOCKS_GRAY_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_SHULKER_BOX_POOL0_ENTRIES,
@@ -9349,6 +10495,8 @@ static BLOCKS_GRAY_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_STAINED_GLASS_POOL0_ENTRIES,
@@ -9367,6 +10515,8 @@ static BLOCKS_GRAY_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -9385,6 +10535,8 @@ static BLOCKS_GRAY_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_TERRACOTTA_POOL0_ENTRIES,
@@ -9403,6 +10555,8 @@ static BLOCKS_GRAY_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRAY_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRAY_WOOL_POOL0_ENTRIES,
@@ -9421,6 +10575,8 @@ static BLOCKS_GREEN_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_BANNER_POOL0_ENTRIES,
@@ -9441,6 +10597,8 @@ static BLOCKS_GREEN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_BED_POOL0_ENTRIES,
@@ -9462,6 +10620,8 @@ static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:green_candle",
@@ -9477,6 +10637,8 @@ static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:green_candle",
@@ -9495,6 +10657,8 @@ static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:green_candle",
@@ -9513,6 +10677,8 @@ static BLOCKS_GREEN_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_GREEN_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -9532,6 +10698,8 @@ static BLOCKS_GREEN_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_CANDLE_CAKE_POOL0_ENTRIES,
@@ -9550,6 +10718,8 @@ static BLOCKS_GREEN_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_CARPET_POOL0_ENTRIES,
@@ -9568,6 +10738,8 @@ static BLOCKS_GREEN_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_CONCRETE_POOL0_ENTRIES,
@@ -9586,6 +10758,8 @@ static BLOCKS_GREEN_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -9604,6 +10778,8 @@ static BLOCKS_GREEN_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -9622,6 +10798,8 @@ static BLOCKS_GREEN_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_SHULKER_BOX_POOL0_ENTRIES,
@@ -9640,6 +10818,8 @@ static BLOCKS_GREEN_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_STAINED_GLASS_POOL0_ENTRIES,
@@ -9658,6 +10838,8 @@ static BLOCKS_GREEN_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -9676,6 +10858,8 @@ static BLOCKS_GREEN_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_TERRACOTTA_POOL0_ENTRIES,
@@ -9694,6 +10878,8 @@ static BLOCKS_GREEN_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GREEN_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GREEN_WOOL_POOL0_ENTRIES,
@@ -9712,6 +10898,8 @@ static BLOCKS_GRINDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_GRINDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_GRINDSTONE_POOL0_ENTRIES,
@@ -9730,6 +10918,8 @@ static BLOCKS_HANGING_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HANGING_ROOTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HANGING_ROOTS_POOL0_ENTRIES,
@@ -9748,6 +10938,8 @@ static BLOCKS_HAY_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HAY_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HAY_BLOCK_POOL0_ENTRIES,
@@ -9766,6 +10958,8 @@ static BLOCKS_HEAVY_CORE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HEAVY_CORE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HEAVY_CORE_POOL0_ENTRIES,
@@ -9784,6 +10978,8 @@ static BLOCKS_HEAVY_WEIGHTED_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HEAVY_WEIGHTED_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HEAVY_WEIGHTED_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -9802,6 +10998,8 @@ static BLOCKS_HONEY_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HONEY_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HONEY_BLOCK_POOL0_ENTRIES,
@@ -9820,6 +11018,8 @@ static BLOCKS_HONEYCOMB_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HONEYCOMB_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HONEYCOMB_BLOCK_POOL0_ENTRIES,
@@ -9838,6 +11038,8 @@ static BLOCKS_HOPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HOPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HOPPER_POOL0_ENTRIES,
@@ -9856,6 +11058,8 @@ static BLOCKS_HORN_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HORN_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HORN_CORAL_POOL0_ENTRIES,
@@ -9875,6 +11079,8 @@ static BLOCKS_HORN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_horn_coral_block",
@@ -9886,6 +11092,8 @@ static BLOCKS_HORN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_HORN_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -9905,6 +11113,8 @@ static BLOCKS_HORN_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_HORN_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_HORN_CORAL_FAN_POOL0_ENTRIES,
@@ -9923,6 +11133,8 @@ static BLOCKS_ICE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ICE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ICE_POOL0_ENTRIES,
@@ -9941,6 +11153,8 @@ static BLOCKS_INFESTED_CHISELED_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[Loo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_CHISELED_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_CHISELED_STONE_BRICKS_POOL0_ENTRIES,
@@ -9959,6 +11173,8 @@ static BLOCKS_INFESTED_COBBLESTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_COBBLESTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_COBBLESTONE_POOL0_ENTRIES,
@@ -9977,6 +11193,8 @@ static BLOCKS_INFESTED_CRACKED_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_CRACKED_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_CRACKED_STONE_BRICKS_POOL0_ENTRIES,
@@ -9995,6 +11213,8 @@ static BLOCKS_INFESTED_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_DEEPSLATE_POOL0_ENTRIES,
@@ -10013,6 +11233,8 @@ static BLOCKS_INFESTED_MOSSY_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_MOSSY_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_MOSSY_STONE_BRICKS_POOL0_ENTRIES,
@@ -10031,6 +11253,8 @@ static BLOCKS_INFESTED_STONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_STONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_STONE_POOL0_ENTRIES,
@@ -10049,6 +11273,8 @@ static BLOCKS_INFESTED_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_INFESTED_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_INFESTED_STONE_BRICKS_POOL0_ENTRIES,
@@ -10067,6 +11293,8 @@ static BLOCKS_IRON_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_IRON_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_IRON_BARS_POOL0_ENTRIES,
@@ -10085,6 +11313,8 @@ static BLOCKS_IRON_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_IRON_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_IRON_BLOCK_POOL0_ENTRIES,
@@ -10103,6 +11333,8 @@ static BLOCKS_IRON_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_IRON_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_IRON_CHAIN_POOL0_ENTRIES,
@@ -10123,6 +11355,8 @@ static BLOCKS_IRON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_IRON_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_IRON_DOOR_POOL0_ENTRIES,
@@ -10142,6 +11376,8 @@ static BLOCKS_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:raw_iron",
@@ -10150,6 +11386,8 @@ static BLOCKS_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_IRON_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -10169,6 +11407,8 @@ static BLOCKS_IRON_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_IRON_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_IRON_TRAPDOOR_POOL0_ENTRIES,
@@ -10187,6 +11427,8 @@ static BLOCKS_JACK_O_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JACK_O_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JACK_O_LANTERN_POOL0_ENTRIES,
@@ -10205,6 +11447,8 @@ static BLOCKS_JUKEBOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUKEBOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUKEBOX_POOL0_ENTRIES,
@@ -10223,6 +11467,8 @@ static BLOCKS_JUNGLE_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_BUTTON_POOL0_ENTRIES,
@@ -10243,6 +11489,8 @@ static BLOCKS_JUNGLE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_DOOR_POOL0_ENTRIES,
@@ -10261,6 +11509,8 @@ static BLOCKS_JUNGLE_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_FENCE_POOL0_ENTRIES,
@@ -10279,6 +11529,8 @@ static BLOCKS_JUNGLE_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_FENCE_GATE_POOL0_ENTRIES,
@@ -10297,6 +11549,8 @@ static BLOCKS_JUNGLE_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_HANGING_SIGN_POOL0_ENTRIES,
@@ -10316,6 +11570,8 @@ static BLOCKS_JUNGLE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:jungle_sapling",
@@ -10332,6 +11588,8 @@ static BLOCKS_JUNGLE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_JUNGLE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -10343,6 +11601,8 @@ static BLOCKS_JUNGLE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_JUNGLE_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -10370,6 +11630,8 @@ static BLOCKS_JUNGLE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_LOG_POOL0_ENTRIES,
@@ -10388,6 +11650,8 @@ static BLOCKS_JUNGLE_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_PLANKS_POOL0_ENTRIES,
@@ -10406,6 +11670,8 @@ static BLOCKS_JUNGLE_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -10424,6 +11690,8 @@ static BLOCKS_JUNGLE_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_SAPLING_POOL0_ENTRIES,
@@ -10442,6 +11710,8 @@ static BLOCKS_JUNGLE_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_SHELF_POOL0_ENTRIES,
@@ -10460,6 +11730,8 @@ static BLOCKS_JUNGLE_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_SIGN_POOL0_ENTRIES,
@@ -10481,6 +11753,8 @@ static BLOCKS_JUNGLE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:jungle_slab",
@@ -10491,6 +11765,8 @@ static BLOCKS_JUNGLE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_JUNGLE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -10510,6 +11786,8 @@ static BLOCKS_JUNGLE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_STAIRS_POOL0_ENTRIES,
@@ -10528,6 +11806,8 @@ static BLOCKS_JUNGLE_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_TRAPDOOR_POOL0_ENTRIES,
@@ -10546,6 +11826,8 @@ static BLOCKS_JUNGLE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_JUNGLE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_JUNGLE_WOOD_POOL0_ENTRIES,
@@ -10564,6 +11846,8 @@ static BLOCKS_KELP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_KELP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_KELP_POOL0_ENTRIES,
@@ -10582,6 +11866,8 @@ static BLOCKS_KELP_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_KELP_PLANT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_KELP_PLANT_POOL0_ENTRIES,
@@ -10600,6 +11886,8 @@ static BLOCKS_LADDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LADDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LADDER_POOL0_ENTRIES,
@@ -10618,6 +11906,8 @@ static BLOCKS_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LANTERN_POOL0_ENTRIES,
@@ -10636,6 +11926,8 @@ static BLOCKS_LAPIS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LAPIS_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LAPIS_BLOCK_POOL0_ENTRIES,
@@ -10655,6 +11947,8 @@ static BLOCKS_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -10663,6 +11957,8 @@ static BLOCKS_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_LAPIS_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -10682,6 +11978,8 @@ static BLOCKS_LARGE_AMETHYST_BUD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LARGE_AMETHYST_BUD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LARGE_AMETHYST_BUD_POOL0_ENTRIES,
@@ -10701,6 +11999,8 @@ static BLOCKS_LARGE_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -10715,6 +12015,8 @@ static BLOCKS_LARGE_FERN_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
@@ -10725,6 +12027,8 @@ static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -10739,6 +12043,8 @@ static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_LARGE_FERN_POOLS: &[LootPool] = &[
@@ -10771,6 +12077,8 @@ static BLOCKS_LAVA_CAULDRON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LAVA_CAULDRON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LAVA_CAULDRON_POOL0_ENTRIES,
@@ -10792,6 +12100,8 @@ static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("segment_amount", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:leaf_litter",
@@ -10807,6 +12117,8 @@ static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:leaf_litter",
@@ -10825,6 +12137,8 @@ static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:leaf_litter",
@@ -10846,6 +12160,8 @@ static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:leaf_litter",
@@ -10867,6 +12183,8 @@ static BLOCKS_LEAF_LITTER_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_LEAF_LITTER_POOLS: &[LootPool] = &[LootPool {
@@ -10886,6 +12204,8 @@ static BLOCKS_LECTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LECTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LECTERN_POOL0_ENTRIES,
@@ -10904,6 +12224,8 @@ static BLOCKS_LEVER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LEVER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LEVER_POOL0_ENTRIES,
@@ -10922,6 +12244,8 @@ static BLOCKS_LIGHT_BLUE_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_BANNER_POOL0_ENTRIES,
@@ -10942,6 +12266,8 @@ static BLOCKS_LIGHT_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_BED_POOL0_ENTRIES,
@@ -10963,6 +12289,8 @@ static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_blue_candle",
@@ -10978,6 +12306,8 @@ static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_blue_candle",
@@ -10996,6 +12326,8 @@ static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_blue_candle",
@@ -11014,6 +12346,8 @@ static BLOCKS_LIGHT_BLUE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_LIGHT_BLUE_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -11033,6 +12367,8 @@ static BLOCKS_LIGHT_BLUE_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_CANDLE_CAKE_POOL0_ENTRIES,
@@ -11051,6 +12387,8 @@ static BLOCKS_LIGHT_BLUE_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_CARPET_POOL0_ENTRIES,
@@ -11069,6 +12407,8 @@ static BLOCKS_LIGHT_BLUE_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_CONCRETE_POOL0_ENTRIES,
@@ -11087,6 +12427,8 @@ static BLOCKS_LIGHT_BLUE_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -11105,6 +12447,8 @@ static BLOCKS_LIGHT_BLUE_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -11123,6 +12467,8 @@ static BLOCKS_LIGHT_BLUE_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_SHULKER_BOX_POOL0_ENTRIES,
@@ -11141,6 +12487,8 @@ static BLOCKS_LIGHT_BLUE_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_STAINED_GLASS_POOL0_ENTRIES,
@@ -11159,6 +12507,8 @@ static BLOCKS_LIGHT_BLUE_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -11177,6 +12527,8 @@ static BLOCKS_LIGHT_BLUE_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_TERRACOTTA_POOL0_ENTRIES,
@@ -11195,6 +12547,8 @@ static BLOCKS_LIGHT_BLUE_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_BLUE_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_BLUE_WOOL_POOL0_ENTRIES,
@@ -11213,6 +12567,8 @@ static BLOCKS_LIGHT_GRAY_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_BANNER_POOL0_ENTRIES,
@@ -11233,6 +12589,8 @@ static BLOCKS_LIGHT_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_BED_POOL0_ENTRIES,
@@ -11254,6 +12612,8 @@ static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_gray_candle",
@@ -11269,6 +12629,8 @@ static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_gray_candle",
@@ -11287,6 +12649,8 @@ static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:light_gray_candle",
@@ -11305,6 +12669,8 @@ static BLOCKS_LIGHT_GRAY_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_LIGHT_GRAY_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -11324,6 +12690,8 @@ static BLOCKS_LIGHT_GRAY_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_CANDLE_CAKE_POOL0_ENTRIES,
@@ -11342,6 +12710,8 @@ static BLOCKS_LIGHT_GRAY_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_CARPET_POOL0_ENTRIES,
@@ -11360,6 +12730,8 @@ static BLOCKS_LIGHT_GRAY_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_CONCRETE_POOL0_ENTRIES,
@@ -11378,6 +12750,8 @@ static BLOCKS_LIGHT_GRAY_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -11396,6 +12770,8 @@ static BLOCKS_LIGHT_GRAY_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -11414,6 +12790,8 @@ static BLOCKS_LIGHT_GRAY_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_SHULKER_BOX_POOL0_ENTRIES,
@@ -11432,6 +12810,8 @@ static BLOCKS_LIGHT_GRAY_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_STAINED_GLASS_POOL0_ENTRIES,
@@ -11450,6 +12830,8 @@ static BLOCKS_LIGHT_GRAY_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -11468,6 +12850,8 @@ static BLOCKS_LIGHT_GRAY_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_TERRACOTTA_POOL0_ENTRIES,
@@ -11486,6 +12870,8 @@ static BLOCKS_LIGHT_GRAY_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_GRAY_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_GRAY_WOOL_POOL0_ENTRIES,
@@ -11504,6 +12890,8 @@ static BLOCKS_LIGHT_WEIGHTED_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHT_WEIGHTED_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHT_WEIGHTED_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -11522,6 +12910,8 @@ static BLOCKS_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -11542,6 +12932,8 @@ static BLOCKS_LILAC_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LILAC_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LILAC_POOL0_ENTRIES,
@@ -11560,6 +12952,8 @@ static BLOCKS_LILY_OF_THE_VALLEY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LILY_OF_THE_VALLEY_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LILY_OF_THE_VALLEY_POOL0_ENTRIES,
@@ -11578,6 +12972,8 @@ static BLOCKS_LILY_PAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LILY_PAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LILY_PAD_POOL0_ENTRIES,
@@ -11596,6 +12992,8 @@ static BLOCKS_LIME_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_BANNER_POOL0_ENTRIES,
@@ -11616,6 +13014,8 @@ static BLOCKS_LIME_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_BED_POOL0_ENTRIES,
@@ -11637,6 +13037,8 @@ static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:lime_candle",
@@ -11652,6 +13054,8 @@ static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:lime_candle",
@@ -11670,6 +13074,8 @@ static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:lime_candle",
@@ -11688,6 +13094,8 @@ static BLOCKS_LIME_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_LIME_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -11707,6 +13115,8 @@ static BLOCKS_LIME_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_CANDLE_CAKE_POOL0_ENTRIES,
@@ -11725,6 +13135,8 @@ static BLOCKS_LIME_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_CARPET_POOL0_ENTRIES,
@@ -11743,6 +13155,8 @@ static BLOCKS_LIME_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_CONCRETE_POOL0_ENTRIES,
@@ -11761,6 +13175,8 @@ static BLOCKS_LIME_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -11779,6 +13195,8 @@ static BLOCKS_LIME_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -11797,6 +13215,8 @@ static BLOCKS_LIME_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_SHULKER_BOX_POOL0_ENTRIES,
@@ -11815,6 +13235,8 @@ static BLOCKS_LIME_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_STAINED_GLASS_POOL0_ENTRIES,
@@ -11833,6 +13255,8 @@ static BLOCKS_LIME_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -11851,6 +13275,8 @@ static BLOCKS_LIME_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_TERRACOTTA_POOL0_ENTRIES,
@@ -11869,6 +13295,8 @@ static BLOCKS_LIME_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LIME_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LIME_WOOL_POOL0_ENTRIES,
@@ -11887,6 +13315,8 @@ static BLOCKS_LODESTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LODESTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LODESTONE_POOL0_ENTRIES,
@@ -11905,6 +13335,8 @@ static BLOCKS_LOOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_LOOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_LOOM_POOL0_ENTRIES,
@@ -11923,6 +13355,8 @@ static BLOCKS_MAGENTA_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_BANNER_POOL0_ENTRIES,
@@ -11943,6 +13377,8 @@ static BLOCKS_MAGENTA_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_BED_POOL0_ENTRIES,
@@ -11964,6 +13400,8 @@ static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:magenta_candle",
@@ -11979,6 +13417,8 @@ static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:magenta_candle",
@@ -11997,6 +13437,8 @@ static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:magenta_candle",
@@ -12015,6 +13457,8 @@ static BLOCKS_MAGENTA_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MAGENTA_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -12034,6 +13478,8 @@ static BLOCKS_MAGENTA_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_CANDLE_CAKE_POOL0_ENTRIES,
@@ -12052,6 +13498,8 @@ static BLOCKS_MAGENTA_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_CARPET_POOL0_ENTRIES,
@@ -12070,6 +13518,8 @@ static BLOCKS_MAGENTA_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_CONCRETE_POOL0_ENTRIES,
@@ -12088,6 +13538,8 @@ static BLOCKS_MAGENTA_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -12106,6 +13558,8 @@ static BLOCKS_MAGENTA_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -12124,6 +13578,8 @@ static BLOCKS_MAGENTA_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_SHULKER_BOX_POOL0_ENTRIES,
@@ -12142,6 +13598,8 @@ static BLOCKS_MAGENTA_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_STAINED_GLASS_POOL0_ENTRIES,
@@ -12160,6 +13618,8 @@ static BLOCKS_MAGENTA_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -12178,6 +13638,8 @@ static BLOCKS_MAGENTA_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_TERRACOTTA_POOL0_ENTRIES,
@@ -12196,6 +13658,8 @@ static BLOCKS_MAGENTA_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGENTA_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGENTA_WOOL_POOL0_ENTRIES,
@@ -12214,6 +13678,8 @@ static BLOCKS_MAGMA_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MAGMA_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MAGMA_BLOCK_POOL0_ENTRIES,
@@ -12232,6 +13698,8 @@ static BLOCKS_MANGROVE_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_BUTTON_POOL0_ENTRIES,
@@ -12252,6 +13720,8 @@ static BLOCKS_MANGROVE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_DOOR_POOL0_ENTRIES,
@@ -12270,6 +13740,8 @@ static BLOCKS_MANGROVE_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_FENCE_POOL0_ENTRIES,
@@ -12288,6 +13760,8 @@ static BLOCKS_MANGROVE_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_FENCE_GATE_POOL0_ENTRIES,
@@ -12306,6 +13780,8 @@ static BLOCKS_MANGROVE_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_HANGING_SIGN_POOL0_ENTRIES,
@@ -12325,6 +13801,8 @@ static BLOCKS_MANGROVE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -12338,6 +13816,8 @@ static BLOCKS_MANGROVE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MANGROVE_LEAVES_POOLS: &[LootPool] = &[LootPool {
@@ -12357,6 +13837,8 @@ static BLOCKS_MANGROVE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_LOG_POOL0_ENTRIES,
@@ -12375,6 +13857,8 @@ static BLOCKS_MANGROVE_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_PLANKS_POOL0_ENTRIES,
@@ -12393,6 +13877,8 @@ static BLOCKS_MANGROVE_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -12411,6 +13897,8 @@ static BLOCKS_MANGROVE_PROPAGULE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_MANGROVE_PROPAGULE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_PROPAGULE_POOL0_ENTRIES,
@@ -12431,6 +13919,8 @@ static BLOCKS_MANGROVE_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_ROOTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_ROOTS_POOL0_ENTRIES,
@@ -12449,6 +13939,8 @@ static BLOCKS_MANGROVE_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_SHELF_POOL0_ENTRIES,
@@ -12467,6 +13959,8 @@ static BLOCKS_MANGROVE_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_SIGN_POOL0_ENTRIES,
@@ -12488,6 +13982,8 @@ static BLOCKS_MANGROVE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:mangrove_slab",
@@ -12498,6 +13994,8 @@ static BLOCKS_MANGROVE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MANGROVE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -12517,6 +14015,8 @@ static BLOCKS_MANGROVE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_STAIRS_POOL0_ENTRIES,
@@ -12535,6 +14035,8 @@ static BLOCKS_MANGROVE_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_TRAPDOOR_POOL0_ENTRIES,
@@ -12553,6 +14055,8 @@ static BLOCKS_MANGROVE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MANGROVE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MANGROVE_WOOD_POOL0_ENTRIES,
@@ -12571,6 +14075,8 @@ static BLOCKS_MEDIUM_AMETHYST_BUD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MEDIUM_AMETHYST_BUD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MEDIUM_AMETHYST_BUD_POOL0_ENTRIES,
@@ -12590,6 +14096,8 @@ static BLOCKS_MELON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:melon_slice",
@@ -12598,6 +14106,8 @@ static BLOCKS_MELON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: Some((0i32, 9i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MELON_POOLS: &[LootPool] = &[LootPool {
@@ -12620,6 +14130,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "7")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12635,6 +14147,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12653,6 +14167,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12674,6 +14190,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12698,6 +14216,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12725,6 +14245,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12755,6 +14277,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12788,6 +14312,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -12821,6 +14347,8 @@ static BLOCKS_MELON_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MELON_STEM_POOLS: &[LootPool] = &[LootPool {
@@ -12840,6 +14368,8 @@ static BLOCKS_MOSS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSS_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSS_BLOCK_POOL0_ENTRIES,
@@ -12858,6 +14388,8 @@ static BLOCKS_MOSS_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSS_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSS_CARPET_POOL0_ENTRIES,
@@ -12876,6 +14408,8 @@ static BLOCKS_MOSSY_COBBLESTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_COBBLESTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_COBBLESTONE_POOL0_ENTRIES,
@@ -12897,6 +14431,8 @@ static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:mossy_cobblestone_slab",
@@ -12907,6 +14443,8 @@ static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MOSSY_COBBLESTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -12926,6 +14464,8 @@ static BLOCKS_MOSSY_COBBLESTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_COBBLESTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_COBBLESTONE_STAIRS_POOL0_ENTRIES,
@@ -12944,6 +14484,8 @@ static BLOCKS_MOSSY_COBBLESTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_COBBLESTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_COBBLESTONE_WALL_POOL0_ENTRIES,
@@ -12965,6 +14507,8 @@ static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:mossy_stone_brick_slab",
@@ -12975,6 +14519,8 @@ static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MOSSY_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -12994,6 +14540,8 @@ static BLOCKS_MOSSY_STONE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_STONE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_STONE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -13012,6 +14560,8 @@ static BLOCKS_MOSSY_STONE_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_STONE_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_STONE_BRICK_WALL_POOL0_ENTRIES,
@@ -13030,6 +14580,8 @@ static BLOCKS_MOSSY_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MOSSY_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MOSSY_STONE_BRICKS_POOL0_ENTRIES,
@@ -13048,6 +14600,8 @@ static BLOCKS_MUD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUD_POOL0_ENTRIES,
@@ -13069,6 +14623,8 @@ static BLOCKS_MUD_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:mud_brick_slab",
@@ -13079,6 +14635,8 @@ static BLOCKS_MUD_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_MUD_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -13098,6 +14656,8 @@ static BLOCKS_MUD_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUD_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUD_BRICK_STAIRS_POOL0_ENTRIES,
@@ -13116,6 +14676,8 @@ static BLOCKS_MUD_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUD_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUD_BRICK_WALL_POOL0_ENTRIES,
@@ -13134,6 +14696,8 @@ static BLOCKS_MUD_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUD_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUD_BRICKS_POOL0_ENTRIES,
@@ -13152,6 +14716,8 @@ static BLOCKS_MUDDY_MANGROVE_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUDDY_MANGROVE_ROOTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUDDY_MANGROVE_ROOTS_POOL0_ENTRIES,
@@ -13170,6 +14736,8 @@ static BLOCKS_MUSHROOM_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_MUSHROOM_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_MUSHROOM_STEM_POOL0_ENTRIES,
@@ -13189,6 +14757,8 @@ static BLOCKS_MYCELIUM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dirt",
@@ -13200,6 +14770,8 @@ static BLOCKS_MYCELIUM_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_MYCELIUM_POOLS: &[LootPool] = &[LootPool {
@@ -13219,6 +14791,8 @@ static BLOCKS_NETHER_BRICK_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_BRICK_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_BRICK_FENCE_POOL0_ENTRIES,
@@ -13240,6 +14814,8 @@ static BLOCKS_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:nether_brick_slab",
@@ -13250,6 +14826,8 @@ static BLOCKS_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_NETHER_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -13269,6 +14847,8 @@ static BLOCKS_NETHER_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_BRICK_STAIRS_POOL0_ENTRIES,
@@ -13287,6 +14867,8 @@ static BLOCKS_NETHER_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_BRICK_WALL_POOL0_ENTRIES,
@@ -13305,6 +14887,8 @@ static BLOCKS_NETHER_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_BRICKS_POOL0_ENTRIES,
@@ -13324,6 +14908,8 @@ static BLOCKS_NETHER_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -13332,6 +14918,8 @@ static BLOCKS_NETHER_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_NETHER_GOLD_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -13356,6 +14944,8 @@ static BLOCKS_NETHER_QUARTZ_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:quartz",
@@ -13364,6 +14954,8 @@ static BLOCKS_NETHER_QUARTZ_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::OreDrops),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_NETHER_QUARTZ_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -13383,6 +14975,8 @@ static BLOCKS_NETHER_SPROUTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_SPROUTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_SPROUTS_POOL0_ENTRIES,
@@ -13404,6 +14998,8 @@ static BLOCKS_NETHER_WART_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "3")],
         },
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:nether_wart",
@@ -13414,6 +15010,8 @@ static BLOCKS_NETHER_WART_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "3")],
         }),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_NETHER_WART_POOLS: &[LootPool] = &[LootPool {
@@ -13433,6 +15031,8 @@ static BLOCKS_NETHER_WART_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHER_WART_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHER_WART_BLOCK_POOL0_ENTRIES,
@@ -13451,6 +15051,8 @@ static BLOCKS_NETHERITE_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHERITE_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHERITE_BLOCK_POOL0_ENTRIES,
@@ -13469,6 +15071,8 @@ static BLOCKS_NETHERRACK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NETHERRACK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NETHERRACK_POOL0_ENTRIES,
@@ -13487,6 +15091,8 @@ static BLOCKS_NOTE_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_NOTE_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_NOTE_BLOCK_POOL0_ENTRIES,
@@ -13505,6 +15111,8 @@ static BLOCKS_OAK_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_BUTTON_POOL0_ENTRIES,
@@ -13525,6 +15133,8 @@ static BLOCKS_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_DOOR_POOL0_ENTRIES,
@@ -13543,6 +15153,8 @@ static BLOCKS_OAK_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_FENCE_POOL0_ENTRIES,
@@ -13561,6 +15173,8 @@ static BLOCKS_OAK_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_FENCE_GATE_POOL0_ENTRIES,
@@ -13579,6 +15193,8 @@ static BLOCKS_OAK_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_HANGING_SIGN_POOL0_ENTRIES,
@@ -13598,6 +15214,8 @@ static BLOCKS_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_sapling",
@@ -13614,6 +15232,8 @@ static BLOCKS_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -13625,6 +15245,8 @@ static BLOCKS_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:apple",
@@ -13644,6 +15266,8 @@ static BLOCKS_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
         },
     ]),
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -13678,6 +15302,8 @@ static BLOCKS_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_LOG_POOL0_ENTRIES,
@@ -13696,6 +15322,8 @@ static BLOCKS_OAK_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_PLANKS_POOL0_ENTRIES,
@@ -13714,6 +15342,8 @@ static BLOCKS_OAK_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -13732,6 +15362,8 @@ static BLOCKS_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_SAPLING_POOL0_ENTRIES,
@@ -13750,6 +15382,8 @@ static BLOCKS_OAK_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_SHELF_POOL0_ENTRIES,
@@ -13768,6 +15402,8 @@ static BLOCKS_OAK_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_SIGN_POOL0_ENTRIES,
@@ -13789,6 +15425,8 @@ static BLOCKS_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:oak_slab",
@@ -13799,6 +15437,8 @@ static BLOCKS_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -13818,6 +15458,8 @@ static BLOCKS_OAK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_STAIRS_POOL0_ENTRIES,
@@ -13836,6 +15478,8 @@ static BLOCKS_OAK_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_TRAPDOOR_POOL0_ENTRIES,
@@ -13854,6 +15498,8 @@ static BLOCKS_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OAK_WOOD_POOL0_ENTRIES,
@@ -13872,6 +15518,8 @@ static BLOCKS_OBSERVER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OBSERVER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OBSERVER_POOL0_ENTRIES,
@@ -13890,6 +15538,8 @@ static BLOCKS_OBSIDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OBSIDIAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OBSIDIAN_POOL0_ENTRIES,
@@ -13908,6 +15558,8 @@ static BLOCKS_OCHRE_FROGLIGHT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OCHRE_FROGLIGHT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OCHRE_FROGLIGHT_POOL0_ENTRIES,
@@ -13926,6 +15578,8 @@ static BLOCKS_OPEN_EYEBLOSSOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OPEN_EYEBLOSSOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OPEN_EYEBLOSSOM_POOL0_ENTRIES,
@@ -13944,6 +15598,8 @@ static BLOCKS_ORANGE_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_BANNER_POOL0_ENTRIES,
@@ -13964,6 +15620,8 @@ static BLOCKS_ORANGE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_BED_POOL0_ENTRIES,
@@ -13985,6 +15643,8 @@ static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:orange_candle",
@@ -14000,6 +15660,8 @@ static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:orange_candle",
@@ -14018,6 +15680,8 @@ static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:orange_candle",
@@ -14036,6 +15700,8 @@ static BLOCKS_ORANGE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_ORANGE_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -14055,6 +15721,8 @@ static BLOCKS_ORANGE_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_CANDLE_CAKE_POOL0_ENTRIES,
@@ -14073,6 +15741,8 @@ static BLOCKS_ORANGE_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_CARPET_POOL0_ENTRIES,
@@ -14091,6 +15761,8 @@ static BLOCKS_ORANGE_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_CONCRETE_POOL0_ENTRIES,
@@ -14109,6 +15781,8 @@ static BLOCKS_ORANGE_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -14127,6 +15801,8 @@ static BLOCKS_ORANGE_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -14145,6 +15821,8 @@ static BLOCKS_ORANGE_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_SHULKER_BOX_POOL0_ENTRIES,
@@ -14163,6 +15841,8 @@ static BLOCKS_ORANGE_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_STAINED_GLASS_POOL0_ENTRIES,
@@ -14181,6 +15861,8 @@ static BLOCKS_ORANGE_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -14199,6 +15881,8 @@ static BLOCKS_ORANGE_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_TERRACOTTA_POOL0_ENTRIES,
@@ -14217,6 +15901,8 @@ static BLOCKS_ORANGE_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_TULIP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_TULIP_POOL0_ENTRIES,
@@ -14235,6 +15921,8 @@ static BLOCKS_ORANGE_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ORANGE_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ORANGE_WOOL_POOL0_ENTRIES,
@@ -14253,6 +15941,8 @@ static BLOCKS_OXEYE_DAISY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXEYE_DAISY_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXEYE_DAISY_POOL0_ENTRIES,
@@ -14271,6 +15961,8 @@ static BLOCKS_OXIDIZED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -14289,6 +15981,8 @@ static BLOCKS_OXIDIZED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_POOL0_ENTRIES,
@@ -14307,6 +16001,8 @@ static BLOCKS_OXIDIZED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_BARS_POOL0_ENTRIES,
@@ -14325,6 +16021,8 @@ static BLOCKS_OXIDIZED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_BULB_POOL0_ENTRIES,
@@ -14343,6 +16041,8 @@ static BLOCKS_OXIDIZED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -14361,6 +16061,8 @@ static BLOCKS_OXIDIZED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_CHEST_POOL0_ENTRIES,
@@ -14381,6 +16083,8 @@ static BLOCKS_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES,
@@ -14399,6 +16103,8 @@ static BLOCKS_OXIDIZED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -14417,6 +16123,8 @@ static BLOCKS_OXIDIZED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_GRATE_POOL0_ENTRIES,
@@ -14435,6 +16143,8 @@ static BLOCKS_OXIDIZED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -14453,6 +16163,8 @@ static BLOCKS_OXIDIZED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -14471,6 +16183,8 @@ static BLOCKS_OXIDIZED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_CUT_COPPER_POOL0_ENTRIES,
@@ -14492,6 +16206,8 @@ static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:oxidized_cut_copper_slab",
@@ -14502,6 +16218,8 @@ static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_OXIDIZED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -14521,6 +16239,8 @@ static BLOCKS_OXIDIZED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -14539,6 +16259,8 @@ static BLOCKS_OXIDIZED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_OXIDIZED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_OXIDIZED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -14557,6 +16279,8 @@ static BLOCKS_PACKED_ICE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PACKED_ICE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PACKED_ICE_POOL0_ENTRIES,
@@ -14575,6 +16299,8 @@ static BLOCKS_PACKED_MUD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PACKED_MUD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PACKED_MUD_POOL0_ENTRIES,
@@ -14593,6 +16319,8 @@ static BLOCKS_PALE_HANGING_MOSS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_HANGING_MOSS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_HANGING_MOSS_POOL0_ENTRIES,
@@ -14611,6 +16339,8 @@ static BLOCKS_PALE_MOSS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_MOSS_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_MOSS_BLOCK_POOL0_ENTRIES,
@@ -14631,6 +16361,8 @@ static BLOCKS_PALE_MOSS_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("bottom", "true")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_PALE_MOSS_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_MOSS_CARPET_POOL0_ENTRIES,
@@ -14649,6 +16381,8 @@ static BLOCKS_PALE_OAK_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_BUTTON_POOL0_ENTRIES,
@@ -14669,6 +16403,8 @@ static BLOCKS_PALE_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_DOOR_POOL0_ENTRIES,
@@ -14687,6 +16423,8 @@ static BLOCKS_PALE_OAK_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_FENCE_POOL0_ENTRIES,
@@ -14705,6 +16443,8 @@ static BLOCKS_PALE_OAK_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_FENCE_GATE_POOL0_ENTRIES,
@@ -14723,6 +16463,8 @@ static BLOCKS_PALE_OAK_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_HANGING_SIGN_POOL0_ENTRIES,
@@ -14742,6 +16484,8 @@ static BLOCKS_PALE_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pale_oak_sapling",
@@ -14758,6 +16502,8 @@ static BLOCKS_PALE_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_PALE_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -14769,6 +16515,8 @@ static BLOCKS_PALE_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_PALE_OAK_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -14796,6 +16544,8 @@ static BLOCKS_PALE_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_LOG_POOL0_ENTRIES,
@@ -14814,6 +16564,8 @@ static BLOCKS_PALE_OAK_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_PLANKS_POOL0_ENTRIES,
@@ -14832,6 +16584,8 @@ static BLOCKS_PALE_OAK_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -14850,6 +16604,8 @@ static BLOCKS_PALE_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_SAPLING_POOL0_ENTRIES,
@@ -14868,6 +16624,8 @@ static BLOCKS_PALE_OAK_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_SHELF_POOL0_ENTRIES,
@@ -14886,6 +16644,8 @@ static BLOCKS_PALE_OAK_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_SIGN_POOL0_ENTRIES,
@@ -14907,6 +16667,8 @@ static BLOCKS_PALE_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pale_oak_slab",
@@ -14917,6 +16679,8 @@ static BLOCKS_PALE_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PALE_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -14936,6 +16700,8 @@ static BLOCKS_PALE_OAK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_STAIRS_POOL0_ENTRIES,
@@ -14954,6 +16720,8 @@ static BLOCKS_PALE_OAK_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_TRAPDOOR_POOL0_ENTRIES,
@@ -14972,6 +16740,8 @@ static BLOCKS_PALE_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PALE_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PALE_OAK_WOOD_POOL0_ENTRIES,
@@ -14990,6 +16760,8 @@ static BLOCKS_PEARLESCENT_FROGLIGHT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PEARLESCENT_FROGLIGHT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PEARLESCENT_FROGLIGHT_POOL0_ENTRIES,
@@ -15010,6 +16782,8 @@ static BLOCKS_PEONY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PEONY_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PEONY_POOL0_ENTRIES,
@@ -15031,6 +16805,8 @@ static BLOCKS_PETRIFIED_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:petrified_oak_slab",
@@ -15041,6 +16817,8 @@ static BLOCKS_PETRIFIED_OAK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PETRIFIED_OAK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -15060,6 +16838,8 @@ static BLOCKS_PIGLIN_HEAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PIGLIN_HEAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PIGLIN_HEAD_POOL0_ENTRIES,
@@ -15078,6 +16858,8 @@ static BLOCKS_PINK_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_BANNER_POOL0_ENTRIES,
@@ -15098,6 +16880,8 @@ static BLOCKS_PINK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_BED_POOL0_ENTRIES,
@@ -15119,6 +16903,8 @@ static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_candle",
@@ -15134,6 +16920,8 @@ static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_candle",
@@ -15152,6 +16940,8 @@ static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_candle",
@@ -15170,6 +16960,8 @@ static BLOCKS_PINK_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PINK_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -15189,6 +16981,8 @@ static BLOCKS_PINK_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_CANDLE_CAKE_POOL0_ENTRIES,
@@ -15207,6 +17001,8 @@ static BLOCKS_PINK_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_CARPET_POOL0_ENTRIES,
@@ -15225,6 +17021,8 @@ static BLOCKS_PINK_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_CONCRETE_POOL0_ENTRIES,
@@ -15243,6 +17041,8 @@ static BLOCKS_PINK_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -15261,6 +17061,8 @@ static BLOCKS_PINK_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -15282,6 +17084,8 @@ static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("flower_amount", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_petals",
@@ -15297,6 +17101,8 @@ static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_petals",
@@ -15315,6 +17121,8 @@ static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_petals",
@@ -15336,6 +17144,8 @@ static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pink_petals",
@@ -15357,6 +17167,8 @@ static BLOCKS_PINK_PETALS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PINK_PETALS_POOLS: &[LootPool] = &[LootPool {
@@ -15376,6 +17188,8 @@ static BLOCKS_PINK_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_SHULKER_BOX_POOL0_ENTRIES,
@@ -15394,6 +17208,8 @@ static BLOCKS_PINK_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_STAINED_GLASS_POOL0_ENTRIES,
@@ -15412,6 +17228,8 @@ static BLOCKS_PINK_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -15430,6 +17248,8 @@ static BLOCKS_PINK_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_TERRACOTTA_POOL0_ENTRIES,
@@ -15448,6 +17268,8 @@ static BLOCKS_PINK_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_TULIP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_TULIP_POOL0_ENTRIES,
@@ -15466,6 +17288,8 @@ static BLOCKS_PINK_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PINK_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PINK_WOOL_POOL0_ENTRIES,
@@ -15484,6 +17308,8 @@ static BLOCKS_PISTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PISTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PISTON_POOL0_ENTRIES,
@@ -15510,6 +17336,8 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pitcher_pod",
@@ -15535,6 +17363,8 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pitcher_pod",
@@ -15570,6 +17400,8 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pitcher_pod",
@@ -15613,6 +17445,8 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pitcher_plant",
@@ -15664,6 +17498,8 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PITCHER_CROP_POOLS: &[LootPool] = &[LootPool {
@@ -15685,6 +17521,8 @@ static BLOCKS_PITCHER_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_PITCHER_PLANT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PITCHER_PLANT_POOL0_ENTRIES,
@@ -15703,6 +17541,8 @@ static BLOCKS_PLAYER_HEAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PLAYER_HEAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PLAYER_HEAD_POOL0_ENTRIES,
@@ -15722,6 +17562,8 @@ static BLOCKS_PODZOL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dirt",
@@ -15733,6 +17575,8 @@ static BLOCKS_PODZOL_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_PODZOL_POOLS: &[LootPool] = &[LootPool {
@@ -15752,6 +17596,8 @@ static BLOCKS_POINTED_DRIPSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POINTED_DRIPSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POINTED_DRIPSTONE_POOL0_ENTRIES,
@@ -15770,6 +17616,8 @@ static BLOCKS_POLISHED_ANDESITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_ANDESITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_ANDESITE_POOL0_ENTRIES,
@@ -15791,6 +17639,8 @@ static BLOCKS_POLISHED_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_andesite_slab",
@@ -15801,6 +17651,8 @@ static BLOCKS_POLISHED_ANDESITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_ANDESITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -15820,6 +17672,8 @@ static BLOCKS_POLISHED_ANDESITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_ANDESITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_ANDESITE_STAIRS_POOL0_ENTRIES,
@@ -15838,6 +17692,8 @@ static BLOCKS_POLISHED_BASALT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BASALT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BASALT_POOL0_ENTRIES,
@@ -15856,6 +17712,8 @@ static BLOCKS_POLISHED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_POOL0_ENTRIES,
@@ -15877,6 +17735,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_blackstone_brick_slab",
@@ -15887,6 +17747,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_BLACKSTONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -15906,6 +17768,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[L
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -15924,6 +17788,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[Loo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_BRICK_WALL_POOL0_ENTRIES,
@@ -15942,6 +17808,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_BRICKS_POOL0_ENTRIES,
@@ -15960,6 +17828,8 @@ static BLOCKS_POLISHED_BLACKSTONE_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_BUTTON_POOL0_ENTRIES,
@@ -15978,6 +17848,8 @@ static BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -15999,6 +17871,8 @@ static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_blackstone_slab",
@@ -16009,6 +17883,8 @@ static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_BLACKSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16028,6 +17904,8 @@ static BLOCKS_POLISHED_BLACKSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_STAIRS_POOL0_ENTRIES,
@@ -16046,6 +17924,8 @@ static BLOCKS_POLISHED_BLACKSTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_BLACKSTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_BLACKSTONE_WALL_POOL0_ENTRIES,
@@ -16064,6 +17944,8 @@ static BLOCKS_POLISHED_CINNABAR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_CINNABAR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_CINNABAR_POOL0_ENTRIES,
@@ -16085,6 +17967,8 @@ static BLOCKS_POLISHED_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_cinnabar_slab",
@@ -16095,6 +17979,8 @@ static BLOCKS_POLISHED_CINNABAR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_CINNABAR_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16114,6 +18000,8 @@ static BLOCKS_POLISHED_CINNABAR_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_CINNABAR_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_CINNABAR_STAIRS_POOL0_ENTRIES,
@@ -16132,6 +18020,8 @@ static BLOCKS_POLISHED_CINNABAR_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_CINNABAR_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_CINNABAR_WALL_POOL0_ENTRIES,
@@ -16150,6 +18040,8 @@ static BLOCKS_POLISHED_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_DEEPSLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DEEPSLATE_POOL0_ENTRIES,
@@ -16171,6 +18063,8 @@ static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_deepslate_slab",
@@ -16181,6 +18075,8 @@ static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_DEEPSLATE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16200,6 +18096,8 @@ static BLOCKS_POLISHED_DEEPSLATE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_DEEPSLATE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DEEPSLATE_STAIRS_POOL0_ENTRIES,
@@ -16218,6 +18116,8 @@ static BLOCKS_POLISHED_DEEPSLATE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_DEEPSLATE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DEEPSLATE_WALL_POOL0_ENTRIES,
@@ -16236,6 +18136,8 @@ static BLOCKS_POLISHED_DIORITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_DIORITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DIORITE_POOL0_ENTRIES,
@@ -16257,6 +18159,8 @@ static BLOCKS_POLISHED_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_diorite_slab",
@@ -16267,6 +18171,8 @@ static BLOCKS_POLISHED_DIORITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_DIORITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16286,6 +18192,8 @@ static BLOCKS_POLISHED_DIORITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_DIORITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_DIORITE_STAIRS_POOL0_ENTRIES,
@@ -16304,6 +18212,8 @@ static BLOCKS_POLISHED_GRANITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_GRANITE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_GRANITE_POOL0_ENTRIES,
@@ -16325,6 +18235,8 @@ static BLOCKS_POLISHED_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_granite_slab",
@@ -16335,6 +18247,8 @@ static BLOCKS_POLISHED_GRANITE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_GRANITE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16354,6 +18268,8 @@ static BLOCKS_POLISHED_GRANITE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_GRANITE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_GRANITE_STAIRS_POOL0_ENTRIES,
@@ -16372,6 +18288,8 @@ static BLOCKS_POLISHED_SULFUR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_SULFUR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_SULFUR_POOL0_ENTRIES,
@@ -16393,6 +18311,8 @@ static BLOCKS_POLISHED_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_sulfur_slab",
@@ -16403,6 +18323,8 @@ static BLOCKS_POLISHED_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_SULFUR_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16422,6 +18344,8 @@ static BLOCKS_POLISHED_SULFUR_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_SULFUR_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_SULFUR_STAIRS_POOL0_ENTRIES,
@@ -16440,6 +18364,8 @@ static BLOCKS_POLISHED_SULFUR_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_SULFUR_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_SULFUR_WALL_POOL0_ENTRIES,
@@ -16458,6 +18384,8 @@ static BLOCKS_POLISHED_TUFF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_TUFF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_TUFF_POOL0_ENTRIES,
@@ -16479,6 +18407,8 @@ static BLOCKS_POLISHED_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:polished_tuff_slab",
@@ -16489,6 +18419,8 @@ static BLOCKS_POLISHED_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_POLISHED_TUFF_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -16508,6 +18440,8 @@ static BLOCKS_POLISHED_TUFF_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_TUFF_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_TUFF_STAIRS_POOL0_ENTRIES,
@@ -16526,6 +18460,8 @@ static BLOCKS_POLISHED_TUFF_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POLISHED_TUFF_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POLISHED_TUFF_WALL_POOL0_ENTRIES,
@@ -16544,6 +18480,8 @@ static BLOCKS_POPPY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POPPY_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POPPY_POOL0_ENTRIES,
@@ -16562,6 +18500,8 @@ static BLOCKS_POTATOES_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_POTATOES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:potato",
@@ -16573,6 +18513,8 @@ static BLOCKS_POTATOES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         extra: 3i32,
         probability: 0.5714286f32,
     }),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_POTATOES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:poisonous_potato",
@@ -16581,6 +18523,8 @@ static BLOCKS_POTATOES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::RandomChance { chance: 0.02f32 },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_POTATOES_POOLS: &[LootPool] = &[
     LootPool {
@@ -16619,6 +18563,8 @@ static BLOCKS_POTENT_SULFUR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTENT_SULFUR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POTENT_SULFUR_POOL0_ENTRIES,
@@ -16637,6 +18583,8 @@ static BLOCKS_POTTED_ACACIA_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ACACIA_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:acacia_sapling",
@@ -16645,6 +18593,8 @@ static BLOCKS_POTTED_ACACIA_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ACACIA_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -16672,6 +18622,8 @@ static BLOCKS_POTTED_ALLIUM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ALLIUM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:allium",
@@ -16680,6 +18632,8 @@ static BLOCKS_POTTED_ALLIUM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ALLIUM_POOLS: &[LootPool] = &[
     LootPool {
@@ -16707,6 +18661,8 @@ static BLOCKS_POTTED_AZALEA_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_AZALEA_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:azalea",
@@ -16715,6 +18671,8 @@ static BLOCKS_POTTED_AZALEA_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_AZALEA_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -16742,6 +18700,8 @@ static BLOCKS_POTTED_AZURE_BLUET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_AZURE_BLUET_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:azure_bluet",
@@ -16750,6 +18710,8 @@ static BLOCKS_POTTED_AZURE_BLUET_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_AZURE_BLUET_POOLS: &[LootPool] = &[
     LootPool {
@@ -16777,6 +18739,8 @@ static BLOCKS_POTTED_BAMBOO_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BAMBOO_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bamboo",
@@ -16785,6 +18749,8 @@ static BLOCKS_POTTED_BAMBOO_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BAMBOO_POOLS: &[LootPool] = &[
     LootPool {
@@ -16812,6 +18778,8 @@ static BLOCKS_POTTED_BIRCH_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BIRCH_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:birch_sapling",
@@ -16820,6 +18788,8 @@ static BLOCKS_POTTED_BIRCH_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BIRCH_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -16847,6 +18817,8 @@ static BLOCKS_POTTED_BLUE_ORCHID_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BLUE_ORCHID_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:blue_orchid",
@@ -16855,6 +18827,8 @@ static BLOCKS_POTTED_BLUE_ORCHID_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BLUE_ORCHID_POOLS: &[LootPool] = &[
     LootPool {
@@ -16882,6 +18856,8 @@ static BLOCKS_POTTED_BROWN_MUSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BROWN_MUSHROOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:brown_mushroom",
@@ -16890,6 +18866,8 @@ static BLOCKS_POTTED_BROWN_MUSHROOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_BROWN_MUSHROOM_POOLS: &[LootPool] = &[
     LootPool {
@@ -16917,6 +18895,8 @@ static BLOCKS_POTTED_CACTUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CACTUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:cactus",
@@ -16925,6 +18905,8 @@ static BLOCKS_POTTED_CACTUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CACTUS_POOLS: &[LootPool] = &[
     LootPool {
@@ -16952,6 +18934,8 @@ static BLOCKS_POTTED_CHERRY_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CHERRY_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:cherry_sapling",
@@ -16960,6 +18944,8 @@ static BLOCKS_POTTED_CHERRY_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CHERRY_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -16987,6 +18973,8 @@ static BLOCKS_POTTED_CLOSED_EYEBLOSSOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CLOSED_EYEBLOSSOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:closed_eyeblossom",
@@ -16995,6 +18983,8 @@ static BLOCKS_POTTED_CLOSED_EYEBLOSSOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CLOSED_EYEBLOSSOM_POOLS: &[LootPool] = &[
     LootPool {
@@ -17022,6 +19012,8 @@ static BLOCKS_POTTED_CORNFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CORNFLOWER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:cornflower",
@@ -17030,6 +19022,8 @@ static BLOCKS_POTTED_CORNFLOWER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CORNFLOWER_POOLS: &[LootPool] = &[
     LootPool {
@@ -17057,6 +19051,8 @@ static BLOCKS_POTTED_CRIMSON_FUNGUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CRIMSON_FUNGUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:crimson_fungus",
@@ -17065,6 +19061,8 @@ static BLOCKS_POTTED_CRIMSON_FUNGUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CRIMSON_FUNGUS_POOLS: &[LootPool] = &[
     LootPool {
@@ -17092,6 +19090,8 @@ static BLOCKS_POTTED_CRIMSON_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CRIMSON_ROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:crimson_roots",
@@ -17100,6 +19100,8 @@ static BLOCKS_POTTED_CRIMSON_ROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_CRIMSON_ROOTS_POOLS: &[LootPool] = &[
     LootPool {
@@ -17127,6 +19129,8 @@ static BLOCKS_POTTED_DANDELION_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DANDELION_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:dandelion",
@@ -17135,6 +19139,8 @@ static BLOCKS_POTTED_DANDELION_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DANDELION_POOLS: &[LootPool] = &[
     LootPool {
@@ -17162,6 +19168,8 @@ static BLOCKS_POTTED_DARK_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DARK_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:dark_oak_sapling",
@@ -17170,6 +19178,8 @@ static BLOCKS_POTTED_DARK_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DARK_OAK_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -17197,6 +19207,8 @@ static BLOCKS_POTTED_DEAD_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DEAD_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:dead_bush",
@@ -17205,6 +19217,8 @@ static BLOCKS_POTTED_DEAD_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_DEAD_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -17232,6 +19246,8 @@ static BLOCKS_POTTED_FERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_FERN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:fern",
@@ -17240,6 +19256,8 @@ static BLOCKS_POTTED_FERN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_FERN_POOLS: &[LootPool] = &[
     LootPool {
@@ -17267,6 +19285,8 @@ static BLOCKS_POTTED_FLOWERING_AZALEA_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_FLOWERING_AZALEA_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:flowering_azalea",
@@ -17275,6 +19295,8 @@ static BLOCKS_POTTED_FLOWERING_AZALEA_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_FLOWERING_AZALEA_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -17302,6 +19324,8 @@ static BLOCKS_POTTED_GOLDEN_DANDELION_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_GOLDEN_DANDELION_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:golden_dandelion",
@@ -17310,6 +19334,8 @@ static BLOCKS_POTTED_GOLDEN_DANDELION_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_GOLDEN_DANDELION_POOLS: &[LootPool] = &[
     LootPool {
@@ -17337,6 +19363,8 @@ static BLOCKS_POTTED_JUNGLE_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_JUNGLE_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:jungle_sapling",
@@ -17345,6 +19373,8 @@ static BLOCKS_POTTED_JUNGLE_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_JUNGLE_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -17372,6 +19402,8 @@ static BLOCKS_POTTED_LILY_OF_THE_VALLEY_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_LILY_OF_THE_VALLEY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:lily_of_the_valley",
@@ -17380,6 +19412,8 @@ static BLOCKS_POTTED_LILY_OF_THE_VALLEY_POOL1_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_LILY_OF_THE_VALLEY_POOLS: &[LootPool] = &[
     LootPool {
@@ -17407,6 +19441,8 @@ static BLOCKS_POTTED_MANGROVE_PROPAGULE_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_MANGROVE_PROPAGULE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:mangrove_propagule",
@@ -17415,6 +19451,8 @@ static BLOCKS_POTTED_MANGROVE_PROPAGULE_POOL1_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_MANGROVE_PROPAGULE_POOLS: &[LootPool] = &[
     LootPool {
@@ -17442,6 +19480,8 @@ static BLOCKS_POTTED_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:oak_sapling",
@@ -17450,6 +19490,8 @@ static BLOCKS_POTTED_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OAK_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -17477,6 +19519,8 @@ static BLOCKS_POTTED_OPEN_EYEBLOSSOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OPEN_EYEBLOSSOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:open_eyeblossom",
@@ -17485,6 +19529,8 @@ static BLOCKS_POTTED_OPEN_EYEBLOSSOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OPEN_EYEBLOSSOM_POOLS: &[LootPool] = &[
     LootPool {
@@ -17512,6 +19558,8 @@ static BLOCKS_POTTED_ORANGE_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ORANGE_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:orange_tulip",
@@ -17520,6 +19568,8 @@ static BLOCKS_POTTED_ORANGE_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_ORANGE_TULIP_POOLS: &[LootPool] = &[
     LootPool {
@@ -17547,6 +19597,8 @@ static BLOCKS_POTTED_OXEYE_DAISY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OXEYE_DAISY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:oxeye_daisy",
@@ -17555,6 +19607,8 @@ static BLOCKS_POTTED_OXEYE_DAISY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_OXEYE_DAISY_POOLS: &[LootPool] = &[
     LootPool {
@@ -17582,6 +19636,8 @@ static BLOCKS_POTTED_PALE_OAK_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_PALE_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:pale_oak_sapling",
@@ -17590,6 +19646,8 @@ static BLOCKS_POTTED_PALE_OAK_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_PALE_OAK_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -17617,6 +19675,8 @@ static BLOCKS_POTTED_PINK_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_PINK_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:pink_tulip",
@@ -17625,6 +19685,8 @@ static BLOCKS_POTTED_PINK_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_PINK_TULIP_POOLS: &[LootPool] = &[
     LootPool {
@@ -17652,6 +19714,8 @@ static BLOCKS_POTTED_POPPY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_POPPY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:poppy",
@@ -17660,6 +19724,8 @@ static BLOCKS_POTTED_POPPY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_POPPY_POOLS: &[LootPool] = &[
     LootPool {
@@ -17687,6 +19753,8 @@ static BLOCKS_POTTED_RED_MUSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_RED_MUSHROOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:red_mushroom",
@@ -17695,6 +19763,8 @@ static BLOCKS_POTTED_RED_MUSHROOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_RED_MUSHROOM_POOLS: &[LootPool] = &[
     LootPool {
@@ -17722,6 +19792,8 @@ static BLOCKS_POTTED_RED_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_RED_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:red_tulip",
@@ -17730,6 +19802,8 @@ static BLOCKS_POTTED_RED_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_RED_TULIP_POOLS: &[LootPool] = &[
     LootPool {
@@ -17757,6 +19831,8 @@ static BLOCKS_POTTED_SPRUCE_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_SPRUCE_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:spruce_sapling",
@@ -17765,6 +19841,8 @@ static BLOCKS_POTTED_SPRUCE_SAPLING_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_SPRUCE_SAPLING_POOLS: &[LootPool] = &[
     LootPool {
@@ -17792,6 +19870,8 @@ static BLOCKS_POTTED_TORCHFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_TORCHFLOWER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:torchflower",
@@ -17800,6 +19880,8 @@ static BLOCKS_POTTED_TORCHFLOWER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_TORCHFLOWER_POOLS: &[LootPool] = &[
     LootPool {
@@ -17827,6 +19909,8 @@ static BLOCKS_POTTED_WARPED_FUNGUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WARPED_FUNGUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:warped_fungus",
@@ -17835,6 +19919,8 @@ static BLOCKS_POTTED_WARPED_FUNGUS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WARPED_FUNGUS_POOLS: &[LootPool] = &[
     LootPool {
@@ -17862,6 +19948,8 @@ static BLOCKS_POTTED_WARPED_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WARPED_ROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:warped_roots",
@@ -17870,6 +19958,8 @@ static BLOCKS_POTTED_WARPED_ROOTS_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WARPED_ROOTS_POOLS: &[LootPool] = &[
     LootPool {
@@ -17897,6 +19987,8 @@ static BLOCKS_POTTED_WHITE_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WHITE_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:white_tulip",
@@ -17905,6 +19997,8 @@ static BLOCKS_POTTED_WHITE_TULIP_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WHITE_TULIP_POOLS: &[LootPool] = &[
     LootPool {
@@ -17932,6 +20026,8 @@ static BLOCKS_POTTED_WITHER_ROSE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WITHER_ROSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:wither_rose",
@@ -17940,6 +20036,8 @@ static BLOCKS_POTTED_WITHER_ROSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POTTED_WITHER_ROSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -17971,6 +20069,8 @@ static BLOCKS_POWDER_SNOW_CAULDRON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POWDER_SNOW_CAULDRON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POWDER_SNOW_CAULDRON_POOL0_ENTRIES,
@@ -17989,6 +20089,8 @@ static BLOCKS_POWERED_RAIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_POWERED_RAIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_POWERED_RAIL_POOL0_ENTRIES,
@@ -18007,6 +20109,8 @@ static BLOCKS_PRISMARINE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PRISMARINE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_POOL0_ENTRIES,
@@ -18028,6 +20132,8 @@ static BLOCKS_PRISMARINE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:prismarine_brick_slab",
@@ -18038,6 +20144,8 @@ static BLOCKS_PRISMARINE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PRISMARINE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -18057,6 +20165,8 @@ static BLOCKS_PRISMARINE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PRISMARINE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -18075,6 +20185,8 @@ static BLOCKS_PRISMARINE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PRISMARINE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_BRICKS_POOL0_ENTRIES,
@@ -18096,6 +20208,8 @@ static BLOCKS_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:prismarine_slab",
@@ -18106,6 +20220,8 @@ static BLOCKS_PRISMARINE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PRISMARINE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -18125,6 +20241,8 @@ static BLOCKS_PRISMARINE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PRISMARINE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_STAIRS_POOL0_ENTRIES,
@@ -18143,6 +20261,8 @@ static BLOCKS_PRISMARINE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PRISMARINE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PRISMARINE_WALL_POOL0_ENTRIES,
@@ -18161,6 +20281,8 @@ static BLOCKS_PUMPKIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PUMPKIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PUMPKIN_POOL0_ENTRIES,
@@ -18182,6 +20304,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "7")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18197,6 +20321,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18215,6 +20341,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18236,6 +20364,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18260,6 +20390,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18287,6 +20419,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18317,6 +20451,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18350,6 +20486,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -18383,6 +20521,8 @@ static BLOCKS_PUMPKIN_STEM_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PUMPKIN_STEM_POOLS: &[LootPool] = &[LootPool {
@@ -18402,6 +20542,8 @@ static BLOCKS_PURPLE_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_BANNER_POOL0_ENTRIES,
@@ -18422,6 +20564,8 @@ static BLOCKS_PURPLE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_BED_POOL0_ENTRIES,
@@ -18443,6 +20587,8 @@ static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:purple_candle",
@@ -18458,6 +20604,8 @@ static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:purple_candle",
@@ -18476,6 +20624,8 @@ static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:purple_candle",
@@ -18494,6 +20644,8 @@ static BLOCKS_PURPLE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PURPLE_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -18513,6 +20665,8 @@ static BLOCKS_PURPLE_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_CANDLE_CAKE_POOL0_ENTRIES,
@@ -18531,6 +20685,8 @@ static BLOCKS_PURPLE_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_CARPET_POOL0_ENTRIES,
@@ -18549,6 +20705,8 @@ static BLOCKS_PURPLE_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_CONCRETE_POOL0_ENTRIES,
@@ -18567,6 +20725,8 @@ static BLOCKS_PURPLE_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -18585,6 +20745,8 @@ static BLOCKS_PURPLE_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -18603,6 +20765,8 @@ static BLOCKS_PURPLE_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_SHULKER_BOX_POOL0_ENTRIES,
@@ -18621,6 +20785,8 @@ static BLOCKS_PURPLE_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_STAINED_GLASS_POOL0_ENTRIES,
@@ -18639,6 +20805,8 @@ static BLOCKS_PURPLE_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -18657,6 +20825,8 @@ static BLOCKS_PURPLE_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_TERRACOTTA_POOL0_ENTRIES,
@@ -18675,6 +20845,8 @@ static BLOCKS_PURPLE_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPLE_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPLE_WOOL_POOL0_ENTRIES,
@@ -18693,6 +20865,8 @@ static BLOCKS_PURPUR_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPUR_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPUR_BLOCK_POOL0_ENTRIES,
@@ -18711,6 +20885,8 @@ static BLOCKS_PURPUR_PILLAR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPUR_PILLAR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPUR_PILLAR_POOL0_ENTRIES,
@@ -18732,6 +20908,8 @@ static BLOCKS_PURPUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:purpur_slab",
@@ -18742,6 +20920,8 @@ static BLOCKS_PURPUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_PURPUR_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -18761,6 +20941,8 @@ static BLOCKS_PURPUR_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_PURPUR_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_PURPUR_STAIRS_POOL0_ENTRIES,
@@ -18779,6 +20961,8 @@ static BLOCKS_QUARTZ_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_QUARTZ_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_QUARTZ_BLOCK_POOL0_ENTRIES,
@@ -18797,6 +20981,8 @@ static BLOCKS_QUARTZ_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_QUARTZ_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_QUARTZ_BRICKS_POOL0_ENTRIES,
@@ -18815,6 +21001,8 @@ static BLOCKS_QUARTZ_PILLAR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_QUARTZ_PILLAR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_QUARTZ_PILLAR_POOL0_ENTRIES,
@@ -18836,6 +21024,8 @@ static BLOCKS_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:quartz_slab",
@@ -18846,6 +21036,8 @@ static BLOCKS_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_QUARTZ_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -18865,6 +21057,8 @@ static BLOCKS_QUARTZ_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_QUARTZ_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_QUARTZ_STAIRS_POOL0_ENTRIES,
@@ -18883,6 +21077,8 @@ static BLOCKS_RAIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RAIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RAIL_POOL0_ENTRIES,
@@ -18901,6 +21097,8 @@ static BLOCKS_RAW_COPPER_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RAW_COPPER_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RAW_COPPER_BLOCK_POOL0_ENTRIES,
@@ -18919,6 +21117,8 @@ static BLOCKS_RAW_GOLD_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RAW_GOLD_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RAW_GOLD_BLOCK_POOL0_ENTRIES,
@@ -18937,6 +21137,8 @@ static BLOCKS_RAW_IRON_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RAW_IRON_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RAW_IRON_BLOCK_POOL0_ENTRIES,
@@ -18955,6 +21157,8 @@ static BLOCKS_RED_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_BANNER_POOL0_ENTRIES,
@@ -18975,6 +21179,8 @@ static BLOCKS_RED_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_BED_POOL0_ENTRIES,
@@ -18996,6 +21202,8 @@ static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:red_candle",
@@ -19011,6 +21219,8 @@ static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:red_candle",
@@ -19029,6 +21239,8 @@ static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:red_candle",
@@ -19047,6 +21259,8 @@ static BLOCKS_RED_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_RED_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -19066,6 +21280,8 @@ static BLOCKS_RED_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_CANDLE_CAKE_POOL0_ENTRIES,
@@ -19084,6 +21300,8 @@ static BLOCKS_RED_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_CARPET_POOL0_ENTRIES,
@@ -19102,6 +21320,8 @@ static BLOCKS_RED_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_CONCRETE_POOL0_ENTRIES,
@@ -19120,6 +21340,8 @@ static BLOCKS_RED_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -19138,6 +21360,8 @@ static BLOCKS_RED_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -19156,6 +21380,8 @@ static BLOCKS_RED_MUSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_MUSHROOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_MUSHROOM_POOL0_ENTRIES,
@@ -19175,6 +21401,8 @@ static BLOCKS_RED_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_mushroom",
@@ -19183,6 +21411,8 @@ static BLOCKS_RED_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: Some((0i32, 2147483647i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_RED_MUSHROOM_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -19205,6 +21435,8 @@ static BLOCKS_RED_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:red_nether_brick_slab",
@@ -19215,6 +21447,8 @@ static BLOCKS_RED_NETHER_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_RED_NETHER_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -19234,6 +21468,8 @@ static BLOCKS_RED_NETHER_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_NETHER_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_NETHER_BRICK_STAIRS_POOL0_ENTRIES,
@@ -19252,6 +21488,8 @@ static BLOCKS_RED_NETHER_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_NETHER_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_NETHER_BRICK_WALL_POOL0_ENTRIES,
@@ -19270,6 +21508,8 @@ static BLOCKS_RED_NETHER_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_NETHER_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_NETHER_BRICKS_POOL0_ENTRIES,
@@ -19288,6 +21528,8 @@ static BLOCKS_RED_SAND_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_SAND_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SAND_POOL0_ENTRIES,
@@ -19306,6 +21548,8 @@ static BLOCKS_RED_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SANDSTONE_POOL0_ENTRIES,
@@ -19327,6 +21571,8 @@ static BLOCKS_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:red_sandstone_slab",
@@ -19337,6 +21583,8 @@ static BLOCKS_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -19356,6 +21604,8 @@ static BLOCKS_RED_SANDSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_SANDSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SANDSTONE_STAIRS_POOL0_ENTRIES,
@@ -19374,6 +21624,8 @@ static BLOCKS_RED_SANDSTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_SANDSTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SANDSTONE_WALL_POOL0_ENTRIES,
@@ -19392,6 +21644,8 @@ static BLOCKS_RED_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_SHULKER_BOX_POOL0_ENTRIES,
@@ -19410,6 +21664,8 @@ static BLOCKS_RED_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_STAINED_GLASS_POOL0_ENTRIES,
@@ -19428,6 +21684,8 @@ static BLOCKS_RED_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -19446,6 +21704,8 @@ static BLOCKS_RED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_TERRACOTTA_POOL0_ENTRIES,
@@ -19464,6 +21724,8 @@ static BLOCKS_RED_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_TULIP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_TULIP_POOL0_ENTRIES,
@@ -19482,6 +21744,8 @@ static BLOCKS_RED_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RED_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RED_WOOL_POOL0_ENTRIES,
@@ -19500,6 +21764,8 @@ static BLOCKS_REDSTONE_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_REDSTONE_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_REDSTONE_BLOCK_POOL0_ENTRIES,
@@ -19518,6 +21784,8 @@ static BLOCKS_REDSTONE_LAMP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_REDSTONE_LAMP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_REDSTONE_LAMP_POOL0_ENTRIES,
@@ -19537,6 +21805,8 @@ static BLOCKS_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -19545,6 +21815,8 @@ static BLOCKS_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_REDSTONE_ORE_POOLS: &[LootPool] = &[LootPool {
@@ -19564,6 +21836,8 @@ static BLOCKS_REDSTONE_TORCH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_REDSTONE_TORCH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_REDSTONE_TORCH_POOL0_ENTRIES,
@@ -19582,6 +21856,8 @@ static BLOCKS_REDSTONE_WIRE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_REDSTONE_WIRE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_REDSTONE_WIRE_POOL0_ENTRIES,
@@ -19604,6 +21880,8 @@ static BLOCKS_REPEATER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_REPEATER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_REPEATER_POOL0_ENTRIES,
@@ -19622,6 +21900,8 @@ static BLOCKS_RESIN_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RESIN_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_BLOCK_POOL0_ENTRIES,
@@ -19643,6 +21923,8 @@ static BLOCKS_RESIN_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:resin_brick_slab",
@@ -19653,6 +21935,8 @@ static BLOCKS_RESIN_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_RESIN_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -19672,6 +21956,8 @@ static BLOCKS_RESIN_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RESIN_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_BRICK_STAIRS_POOL0_ENTRIES,
@@ -19690,6 +21976,8 @@ static BLOCKS_RESIN_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RESIN_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_BRICK_WALL_POOL0_ENTRIES,
@@ -19708,6 +21996,8 @@ static BLOCKS_RESIN_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RESIN_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_BRICKS_POOL0_ENTRIES,
@@ -19726,6 +22016,8 @@ static BLOCKS_RESIN_CLUMP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: -1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_RESIN_CLUMP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESIN_CLUMP_POOL0_ENTRIES,
@@ -19744,6 +22036,8 @@ static BLOCKS_RESPAWN_ANCHOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_RESPAWN_ANCHOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_RESPAWN_ANCHOR_POOL0_ENTRIES,
@@ -19762,6 +22056,8 @@ static BLOCKS_ROOTED_DIRT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ROOTED_DIRT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ROOTED_DIRT_POOL0_ENTRIES,
@@ -19782,6 +22078,8 @@ static BLOCKS_ROSE_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ROSE_BUSH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ROSE_BUSH_POOL0_ENTRIES,
@@ -19800,6 +22098,8 @@ static BLOCKS_SAND_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SAND_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SAND_POOL0_ENTRIES,
@@ -19818,6 +22118,8 @@ static BLOCKS_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SANDSTONE_POOL0_ENTRIES,
@@ -19839,6 +22141,8 @@ static BLOCKS_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sandstone_slab",
@@ -19849,6 +22153,8 @@ static BLOCKS_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -19868,6 +22174,8 @@ static BLOCKS_SANDSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SANDSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SANDSTONE_STAIRS_POOL0_ENTRIES,
@@ -19886,6 +22194,8 @@ static BLOCKS_SANDSTONE_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SANDSTONE_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SANDSTONE_WALL_POOL0_ENTRIES,
@@ -19904,6 +22214,8 @@ static BLOCKS_SCAFFOLDING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SCAFFOLDING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCAFFOLDING_POOL0_ENTRIES,
@@ -19922,6 +22234,8 @@ static BLOCKS_SCULK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SCULK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCULK_POOL0_ENTRIES,
@@ -19940,6 +22254,8 @@ static BLOCKS_SCULK_CATALYST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SCULK_CATALYST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCULK_CATALYST_POOL0_ENTRIES,
@@ -19958,6 +22274,8 @@ static BLOCKS_SCULK_SENSOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SCULK_SENSOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCULK_SENSOR_POOL0_ENTRIES,
@@ -19976,6 +22294,8 @@ static BLOCKS_SCULK_SHRIEKER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SCULK_SHRIEKER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCULK_SHRIEKER_POOL0_ENTRIES,
@@ -19994,6 +22314,8 @@ static BLOCKS_SCULK_VEIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: -1i32,
     condition: LootCondition::SilkTouch,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_SCULK_VEIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SCULK_VEIN_POOL0_ENTRIES,
@@ -20013,6 +22335,8 @@ static BLOCKS_SEA_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:prismarine_crystals",
@@ -20021,6 +22345,8 @@ static BLOCKS_SEA_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: Some((1i32, 5i32)),
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SEA_LANTERN_POOLS: &[LootPool] = &[LootPool {
@@ -20043,6 +22369,8 @@ static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("pickles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sea_pickle",
@@ -20058,6 +22386,8 @@ static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sea_pickle",
@@ -20076,6 +22406,8 @@ static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sea_pickle",
@@ -20094,6 +22426,8 @@ static BLOCKS_SEA_PICKLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SEA_PICKLE_POOLS: &[LootPool] = &[LootPool {
@@ -20113,6 +22447,8 @@ static BLOCKS_SEAGRASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SEAGRASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SEAGRASS_POOL0_ENTRIES,
@@ -20131,6 +22467,8 @@ static BLOCKS_SHORT_DRY_GRASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SHORT_DRY_GRASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SHORT_DRY_GRASS_POOL0_ENTRIES,
@@ -20150,6 +22488,8 @@ static BLOCKS_SHORT_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -20161,6 +22501,8 @@ static BLOCKS_SHORT_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::RandomChance { chance: 0.125f32 },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SHORT_GRASS_POOLS: &[LootPool] = &[LootPool {
@@ -20180,6 +22522,8 @@ static BLOCKS_SHROOMLIGHT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SHROOMLIGHT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SHROOMLIGHT_POOL0_ENTRIES,
@@ -20198,6 +22542,8 @@ static BLOCKS_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SHULKER_BOX_POOL0_ENTRIES,
@@ -20216,6 +22562,8 @@ static BLOCKS_SKELETON_SKULL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SKELETON_SKULL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SKELETON_SKULL_POOL0_ENTRIES,
@@ -20234,6 +22582,8 @@ static BLOCKS_SLIME_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SLIME_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SLIME_BLOCK_POOL0_ENTRIES,
@@ -20252,6 +22602,8 @@ static BLOCKS_SMALL_AMETHYST_BUD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMALL_AMETHYST_BUD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMALL_AMETHYST_BUD_POOL0_ENTRIES,
@@ -20270,6 +22622,8 @@ static BLOCKS_SMALL_DRIPLEAF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMALL_DRIPLEAF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMALL_DRIPLEAF_POOL0_ENTRIES,
@@ -20288,6 +22642,8 @@ static BLOCKS_SMITHING_TABLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMITHING_TABLE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMITHING_TABLE_POOL0_ENTRIES,
@@ -20306,6 +22662,8 @@ static BLOCKS_SMOKER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOKER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOKER_POOL0_ENTRIES,
@@ -20324,6 +22682,8 @@ static BLOCKS_SMOOTH_BASALT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_BASALT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_BASALT_POOL0_ENTRIES,
@@ -20342,6 +22702,8 @@ static BLOCKS_SMOOTH_QUARTZ_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_QUARTZ_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_QUARTZ_POOL0_ENTRIES,
@@ -20363,6 +22725,8 @@ static BLOCKS_SMOOTH_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:smooth_quartz_slab",
@@ -20373,6 +22737,8 @@ static BLOCKS_SMOOTH_QUARTZ_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SMOOTH_QUARTZ_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -20392,6 +22758,8 @@ static BLOCKS_SMOOTH_QUARTZ_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_QUARTZ_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_QUARTZ_STAIRS_POOL0_ENTRIES,
@@ -20410,6 +22778,8 @@ static BLOCKS_SMOOTH_RED_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_RED_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_RED_SANDSTONE_POOL0_ENTRIES,
@@ -20431,6 +22801,8 @@ static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:smooth_red_sandstone_slab",
@@ -20441,6 +22813,8 @@ static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SMOOTH_RED_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -20460,6 +22834,8 @@ static BLOCKS_SMOOTH_RED_SANDSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_RED_SANDSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_RED_SANDSTONE_STAIRS_POOL0_ENTRIES,
@@ -20478,6 +22854,8 @@ static BLOCKS_SMOOTH_SANDSTONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_SANDSTONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_SANDSTONE_POOL0_ENTRIES,
@@ -20499,6 +22877,8 @@ static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:smooth_sandstone_slab",
@@ -20509,6 +22889,8 @@ static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SMOOTH_SANDSTONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -20528,6 +22910,8 @@ static BLOCKS_SMOOTH_SANDSTONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_SANDSTONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_SANDSTONE_STAIRS_POOL0_ENTRIES,
@@ -20546,6 +22930,8 @@ static BLOCKS_SMOOTH_STONE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SMOOTH_STONE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SMOOTH_STONE_POOL0_ENTRIES,
@@ -20567,6 +22953,8 @@ static BLOCKS_SMOOTH_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:smooth_stone_slab",
@@ -20577,6 +22965,8 @@ static BLOCKS_SMOOTH_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SMOOTH_STONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -20596,6 +22986,8 @@ static BLOCKS_SNIFFER_EGG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SNIFFER_EGG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SNIFFER_EGG_POOL0_ENTRIES,
@@ -20620,6 +23012,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20638,6 +23032,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20659,6 +23055,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20683,6 +23081,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20710,6 +23110,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20740,6 +23142,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20773,6 +23177,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -20809,6 +23215,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20822,6 +23230,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20840,6 +23250,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20861,6 +23273,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20885,6 +23299,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20912,6 +23328,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20942,6 +23360,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow",
@@ -20975,6 +23395,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow_block",
@@ -21006,6 +23428,8 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_SNOW_POOLS: &[LootPool] = &[LootPool {
@@ -21026,6 +23450,8 @@ static BLOCKS_SNOW_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -21034,6 +23460,8 @@ static BLOCKS_SNOW_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::NoSilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SNOW_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -21054,6 +23482,8 @@ static BLOCKS_SOUL_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:soul_soil",
@@ -21065,6 +23495,8 @@ static BLOCKS_SOUL_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_SOUL_CAMPFIRE_POOLS: &[LootPool] = &[LootPool {
@@ -21088,6 +23520,8 @@ static BLOCKS_SOUL_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SOUL_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SOUL_LANTERN_POOL0_ENTRIES,
@@ -21106,6 +23540,8 @@ static BLOCKS_SOUL_SAND_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SOUL_SAND_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SOUL_SAND_POOL0_ENTRIES,
@@ -21124,6 +23560,8 @@ static BLOCKS_SOUL_SOIL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SOUL_SOIL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SOUL_SOIL_POOL0_ENTRIES,
@@ -21142,6 +23580,8 @@ static BLOCKS_SOUL_TORCH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SOUL_TORCH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SOUL_TORCH_POOL0_ENTRIES,
@@ -21164,6 +23604,8 @@ static BLOCKS_SPONGE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPONGE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPONGE_POOL0_ENTRIES,
@@ -21182,6 +23624,8 @@ static BLOCKS_SPORE_BLOSSOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPORE_BLOSSOM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPORE_BLOSSOM_POOL0_ENTRIES,
@@ -21200,6 +23644,8 @@ static BLOCKS_SPRUCE_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_BUTTON_POOL0_ENTRIES,
@@ -21220,6 +23666,8 @@ static BLOCKS_SPRUCE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_DOOR_POOL0_ENTRIES,
@@ -21238,6 +23686,8 @@ static BLOCKS_SPRUCE_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_FENCE_POOL0_ENTRIES,
@@ -21256,6 +23706,8 @@ static BLOCKS_SPRUCE_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_FENCE_GATE_POOL0_ENTRIES,
@@ -21274,6 +23726,8 @@ static BLOCKS_SPRUCE_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_HANGING_SIGN_POOL0_ENTRIES,
@@ -21293,6 +23747,8 @@ static BLOCKS_SPRUCE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_sapling",
@@ -21309,6 +23765,8 @@ static BLOCKS_SPRUCE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_SPRUCE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -21320,6 +23778,8 @@ static BLOCKS_SPRUCE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_SPRUCE_LEAVES_POOLS: &[LootPool] = &[
     LootPool {
@@ -21347,6 +23807,8 @@ static BLOCKS_SPRUCE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_LOG_POOL0_ENTRIES,
@@ -21365,6 +23827,8 @@ static BLOCKS_SPRUCE_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_PLANKS_POOL0_ENTRIES,
@@ -21383,6 +23847,8 @@ static BLOCKS_SPRUCE_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -21401,6 +23867,8 @@ static BLOCKS_SPRUCE_SAPLING_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_SAPLING_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_SAPLING_POOL0_ENTRIES,
@@ -21419,6 +23887,8 @@ static BLOCKS_SPRUCE_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_SHELF_POOL0_ENTRIES,
@@ -21437,6 +23907,8 @@ static BLOCKS_SPRUCE_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_SIGN_POOL0_ENTRIES,
@@ -21458,6 +23930,8 @@ static BLOCKS_SPRUCE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:spruce_slab",
@@ -21468,6 +23942,8 @@ static BLOCKS_SPRUCE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SPRUCE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -21487,6 +23963,8 @@ static BLOCKS_SPRUCE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_STAIRS_POOL0_ENTRIES,
@@ -21505,6 +23983,8 @@ static BLOCKS_SPRUCE_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_TRAPDOOR_POOL0_ENTRIES,
@@ -21523,6 +24003,8 @@ static BLOCKS_SPRUCE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SPRUCE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SPRUCE_WOOD_POOL0_ENTRIES,
@@ -21541,6 +24023,8 @@ static BLOCKS_STICKY_PISTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STICKY_PISTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STICKY_PISTON_POOL0_ENTRIES,
@@ -21560,6 +24044,8 @@ static BLOCKS_STONE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cobblestone",
@@ -21571,6 +24057,8 @@ static BLOCKS_STONE_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_STONE_POOLS: &[LootPool] = &[LootPool {
@@ -21593,6 +24081,8 @@ static BLOCKS_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:stone_brick_slab",
@@ -21603,6 +24093,8 @@ static BLOCKS_STONE_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_STONE_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -21622,6 +24114,8 @@ static BLOCKS_STONE_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_BRICK_STAIRS_POOL0_ENTRIES,
@@ -21640,6 +24134,8 @@ static BLOCKS_STONE_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_BRICK_WALL_POOL0_ENTRIES,
@@ -21658,6 +24154,8 @@ static BLOCKS_STONE_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_BRICKS_POOL0_ENTRIES,
@@ -21676,6 +24174,8 @@ static BLOCKS_STONE_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_BUTTON_POOL0_ENTRIES,
@@ -21694,6 +24194,8 @@ static BLOCKS_STONE_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -21715,6 +24217,8 @@ static BLOCKS_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:stone_slab",
@@ -21725,6 +24229,8 @@ static BLOCKS_STONE_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_STONE_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -21744,6 +24250,8 @@ static BLOCKS_STONE_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONE_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONE_STAIRS_POOL0_ENTRIES,
@@ -21762,6 +24270,8 @@ static BLOCKS_STONECUTTER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STONECUTTER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STONECUTTER_POOL0_ENTRIES,
@@ -21780,6 +24290,8 @@ static BLOCKS_STRIPPED_ACACIA_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_ACACIA_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_ACACIA_LOG_POOL0_ENTRIES,
@@ -21798,6 +24310,8 @@ static BLOCKS_STRIPPED_ACACIA_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_ACACIA_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_ACACIA_WOOD_POOL0_ENTRIES,
@@ -21816,6 +24330,8 @@ static BLOCKS_STRIPPED_BAMBOO_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_BAMBOO_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_BAMBOO_BLOCK_POOL0_ENTRIES,
@@ -21834,6 +24350,8 @@ static BLOCKS_STRIPPED_BIRCH_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_BIRCH_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_BIRCH_LOG_POOL0_ENTRIES,
@@ -21852,6 +24370,8 @@ static BLOCKS_STRIPPED_BIRCH_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_BIRCH_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_BIRCH_WOOD_POOL0_ENTRIES,
@@ -21870,6 +24390,8 @@ static BLOCKS_STRIPPED_CHERRY_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_CHERRY_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_CHERRY_LOG_POOL0_ENTRIES,
@@ -21888,6 +24410,8 @@ static BLOCKS_STRIPPED_CHERRY_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_CHERRY_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_CHERRY_WOOD_POOL0_ENTRIES,
@@ -21906,6 +24430,8 @@ static BLOCKS_STRIPPED_CRIMSON_HYPHAE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_CRIMSON_HYPHAE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_CRIMSON_HYPHAE_POOL0_ENTRIES,
@@ -21924,6 +24450,8 @@ static BLOCKS_STRIPPED_CRIMSON_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_CRIMSON_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_CRIMSON_STEM_POOL0_ENTRIES,
@@ -21942,6 +24470,8 @@ static BLOCKS_STRIPPED_DARK_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_DARK_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_DARK_OAK_LOG_POOL0_ENTRIES,
@@ -21960,6 +24490,8 @@ static BLOCKS_STRIPPED_DARK_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_DARK_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_DARK_OAK_WOOD_POOL0_ENTRIES,
@@ -21978,6 +24510,8 @@ static BLOCKS_STRIPPED_JUNGLE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_JUNGLE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_JUNGLE_LOG_POOL0_ENTRIES,
@@ -21996,6 +24530,8 @@ static BLOCKS_STRIPPED_JUNGLE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_JUNGLE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_JUNGLE_WOOD_POOL0_ENTRIES,
@@ -22014,6 +24550,8 @@ static BLOCKS_STRIPPED_MANGROVE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_MANGROVE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_MANGROVE_LOG_POOL0_ENTRIES,
@@ -22032,6 +24570,8 @@ static BLOCKS_STRIPPED_MANGROVE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_MANGROVE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_MANGROVE_WOOD_POOL0_ENTRIES,
@@ -22050,6 +24590,8 @@ static BLOCKS_STRIPPED_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_OAK_LOG_POOL0_ENTRIES,
@@ -22068,6 +24610,8 @@ static BLOCKS_STRIPPED_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_OAK_WOOD_POOL0_ENTRIES,
@@ -22086,6 +24630,8 @@ static BLOCKS_STRIPPED_PALE_OAK_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_PALE_OAK_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_PALE_OAK_LOG_POOL0_ENTRIES,
@@ -22104,6 +24650,8 @@ static BLOCKS_STRIPPED_PALE_OAK_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_PALE_OAK_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_PALE_OAK_WOOD_POOL0_ENTRIES,
@@ -22122,6 +24670,8 @@ static BLOCKS_STRIPPED_SPRUCE_LOG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_SPRUCE_LOG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_SPRUCE_LOG_POOL0_ENTRIES,
@@ -22140,6 +24690,8 @@ static BLOCKS_STRIPPED_SPRUCE_WOOD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_SPRUCE_WOOD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_SPRUCE_WOOD_POOL0_ENTRIES,
@@ -22158,6 +24710,8 @@ static BLOCKS_STRIPPED_WARPED_HYPHAE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_WARPED_HYPHAE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_WARPED_HYPHAE_POOL0_ENTRIES,
@@ -22176,6 +24730,8 @@ static BLOCKS_STRIPPED_WARPED_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_STRIPPED_WARPED_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_STRIPPED_WARPED_STEM_POOL0_ENTRIES,
@@ -22194,6 +24750,8 @@ static BLOCKS_SUGAR_CANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SUGAR_CANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SUGAR_CANE_POOL0_ENTRIES,
@@ -22212,6 +24770,8 @@ static BLOCKS_SULFUR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_POOL0_ENTRIES,
@@ -22233,6 +24793,8 @@ static BLOCKS_SULFUR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sulfur_brick_slab",
@@ -22243,6 +24805,8 @@ static BLOCKS_SULFUR_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SULFUR_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -22262,6 +24826,8 @@ static BLOCKS_SULFUR_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_BRICK_STAIRS_POOL0_ENTRIES,
@@ -22280,6 +24846,8 @@ static BLOCKS_SULFUR_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_BRICK_WALL_POOL0_ENTRIES,
@@ -22298,6 +24866,8 @@ static BLOCKS_SULFUR_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_BRICKS_POOL0_ENTRIES,
@@ -22319,6 +24889,8 @@ static BLOCKS_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:sulfur_slab",
@@ -22329,6 +24901,8 @@ static BLOCKS_SULFUR_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_SULFUR_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -22348,6 +24922,8 @@ static BLOCKS_SULFUR_SPIKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_SPIKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_SPIKE_POOL0_ENTRIES,
@@ -22366,6 +24942,8 @@ static BLOCKS_SULFUR_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_STAIRS_POOL0_ENTRIES,
@@ -22384,6 +24962,8 @@ static BLOCKS_SULFUR_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SULFUR_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SULFUR_WALL_POOL0_ENTRIES,
@@ -22404,6 +24984,8 @@ static BLOCKS_SUNFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_SUNFLOWER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_SUNFLOWER_POOL0_ENTRIES,
@@ -22430,6 +25012,8 @@ static BLOCKS_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
@@ -22438,6 +25022,8 @@ static BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -22469,6 +25055,8 @@ static BLOCKS_TALL_DRY_GRASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TALL_DRY_GRASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TALL_DRY_GRASS_POOL0_ENTRIES,
@@ -22488,6 +25076,8 @@ static BLOCKS_TALL_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -22502,6 +25092,8 @@ static BLOCKS_TALL_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
@@ -22512,6 +25104,8 @@ static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::Shears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -22526,6 +25120,8 @@ static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
             ]),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_TALL_GRASS_POOLS: &[LootPool] = &[
@@ -22558,6 +25154,8 @@ static BLOCKS_TALL_SEAGRASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TALL_SEAGRASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TALL_SEAGRASS_POOL0_ENTRIES,
@@ -22576,6 +25174,8 @@ static BLOCKS_TARGET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TARGET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TARGET_POOL0_ENTRIES,
@@ -22594,6 +25194,8 @@ static BLOCKS_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TERRACOTTA_POOL0_ENTRIES,
@@ -22612,6 +25214,8 @@ static BLOCKS_TINTED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TINTED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TINTED_GLASS_POOL0_ENTRIES,
@@ -22632,6 +25236,8 @@ static BLOCKS_TNT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("unstable", "false")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TNT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TNT_POOL0_ENTRIES,
@@ -22650,6 +25256,8 @@ static BLOCKS_TORCH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TORCH_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TORCH_POOL0_ENTRIES,
@@ -22668,6 +25276,8 @@ static BLOCKS_TORCHFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TORCHFLOWER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TORCHFLOWER_POOL0_ENTRIES,
@@ -22686,6 +25296,8 @@ static BLOCKS_TORCHFLOWER_CROP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_TORCHFLOWER_CROP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TORCHFLOWER_CROP_POOL0_ENTRIES,
@@ -22704,6 +25316,8 @@ static BLOCKS_TRAPPED_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TRAPPED_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TRAPPED_CHEST_POOL0_ENTRIES,
@@ -22726,6 +25340,8 @@ static BLOCKS_TRIPWIRE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TRIPWIRE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TRIPWIRE_POOL0_ENTRIES,
@@ -22744,6 +25360,8 @@ static BLOCKS_TRIPWIRE_HOOK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TRIPWIRE_HOOK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TRIPWIRE_HOOK_POOL0_ENTRIES,
@@ -22762,6 +25380,8 @@ static BLOCKS_TUBE_CORAL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUBE_CORAL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUBE_CORAL_POOL0_ENTRIES,
@@ -22781,6 +25401,8 @@ static BLOCKS_TUBE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_tube_coral_block",
@@ -22792,6 +25414,8 @@ static BLOCKS_TUBE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_TUBE_CORAL_BLOCK_POOLS: &[LootPool] = &[LootPool {
@@ -22811,6 +25435,8 @@ static BLOCKS_TUBE_CORAL_FAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUBE_CORAL_FAN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUBE_CORAL_FAN_POOL0_ENTRIES,
@@ -22829,6 +25455,8 @@ static BLOCKS_TUFF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_POOL0_ENTRIES,
@@ -22850,6 +25478,8 @@ static BLOCKS_TUFF_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:tuff_brick_slab",
@@ -22860,6 +25490,8 @@ static BLOCKS_TUFF_BRICK_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_TUFF_BRICK_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -22879,6 +25511,8 @@ static BLOCKS_TUFF_BRICK_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_BRICK_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_BRICK_STAIRS_POOL0_ENTRIES,
@@ -22897,6 +25531,8 @@ static BLOCKS_TUFF_BRICK_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_BRICK_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_BRICK_WALL_POOL0_ENTRIES,
@@ -22915,6 +25551,8 @@ static BLOCKS_TUFF_BRICKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_BRICKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_BRICKS_POOL0_ENTRIES,
@@ -22936,6 +25574,8 @@ static BLOCKS_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:tuff_slab",
@@ -22946,6 +25586,8 @@ static BLOCKS_TUFF_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_TUFF_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -22965,6 +25607,8 @@ static BLOCKS_TUFF_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_STAIRS_POOL0_ENTRIES,
@@ -22983,6 +25627,8 @@ static BLOCKS_TUFF_WALL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TUFF_WALL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TUFF_WALL_POOL0_ENTRIES,
@@ -23001,6 +25647,8 @@ static BLOCKS_TURTLE_EGG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_TURTLE_EGG_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_TURTLE_EGG_POOL0_ENTRIES,
@@ -23020,6 +25668,8 @@ static BLOCKS_TWISTING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:twisting_vines",
@@ -23033,6 +25683,8 @@ static BLOCKS_TWISTING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_TWISTING_VINES_POOLS: &[LootPool] = &[LootPool {
@@ -23053,6 +25705,8 @@ static BLOCKS_TWISTING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:twisting_vines",
@@ -23066,6 +25720,8 @@ static BLOCKS_TWISTING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_TWISTING_VINES_PLANT_POOLS: &[LootPool] = &[LootPool {
@@ -23089,6 +25745,8 @@ static BLOCKS_VERDANT_FROGLIGHT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_VERDANT_FROGLIGHT_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_VERDANT_FROGLIGHT_POOL0_ENTRIES,
@@ -23107,6 +25765,8 @@ static BLOCKS_VINE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_VINE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_VINE_POOL0_ENTRIES,
@@ -23125,6 +25785,8 @@ static BLOCKS_WARPED_BUTTON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_BUTTON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_BUTTON_POOL0_ENTRIES,
@@ -23145,6 +25807,8 @@ static BLOCKS_WARPED_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_DOOR_POOL0_ENTRIES,
@@ -23163,6 +25827,8 @@ static BLOCKS_WARPED_FENCE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_FENCE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_FENCE_POOL0_ENTRIES,
@@ -23181,6 +25847,8 @@ static BLOCKS_WARPED_FENCE_GATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_FENCE_GATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_FENCE_GATE_POOL0_ENTRIES,
@@ -23199,6 +25867,8 @@ static BLOCKS_WARPED_FUNGUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_FUNGUS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_FUNGUS_POOL0_ENTRIES,
@@ -23217,6 +25887,8 @@ static BLOCKS_WARPED_HANGING_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_HANGING_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_HANGING_SIGN_POOL0_ENTRIES,
@@ -23235,6 +25907,8 @@ static BLOCKS_WARPED_HYPHAE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_HYPHAE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_HYPHAE_POOL0_ENTRIES,
@@ -23254,6 +25928,8 @@ static BLOCKS_WARPED_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouch,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:netherrack",
@@ -23265,6 +25941,8 @@ static BLOCKS_WARPED_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
             LootCondition::SurvivesExplosion,
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_WARPED_NYLIUM_POOLS: &[LootPool] = &[LootPool {
@@ -23284,6 +25962,8 @@ static BLOCKS_WARPED_PLANKS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_PLANKS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_PLANKS_POOL0_ENTRIES,
@@ -23302,6 +25982,8 @@ static BLOCKS_WARPED_PRESSURE_PLATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_PRESSURE_PLATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_PRESSURE_PLATE_POOL0_ENTRIES,
@@ -23320,6 +26002,8 @@ static BLOCKS_WARPED_ROOTS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_ROOTS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_ROOTS_POOL0_ENTRIES,
@@ -23338,6 +26022,8 @@ static BLOCKS_WARPED_SHELF_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_SHELF_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_SHELF_POOL0_ENTRIES,
@@ -23356,6 +26042,8 @@ static BLOCKS_WARPED_SIGN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_SIGN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_SIGN_POOL0_ENTRIES,
@@ -23377,6 +26065,8 @@ static BLOCKS_WARPED_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:warped_slab",
@@ -23387,6 +26077,8 @@ static BLOCKS_WARPED_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WARPED_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -23406,6 +26098,8 @@ static BLOCKS_WARPED_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_STAIRS_POOL0_ENTRIES,
@@ -23424,6 +26118,8 @@ static BLOCKS_WARPED_STEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_STEM_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_STEM_POOL0_ENTRIES,
@@ -23442,6 +26138,8 @@ static BLOCKS_WARPED_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_TRAPDOOR_POOL0_ENTRIES,
@@ -23460,6 +26158,8 @@ static BLOCKS_WARPED_WART_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WARPED_WART_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WARPED_WART_BLOCK_POOL0_ENTRIES,
@@ -23478,6 +26178,8 @@ static BLOCKS_WATER_CAULDRON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WATER_CAULDRON_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WATER_CAULDRON_POOL0_ENTRIES,
@@ -23496,6 +26198,8 @@ static BLOCKS_WAXED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -23514,6 +26218,8 @@ static BLOCKS_WAXED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_BARS_POOL0_ENTRIES,
@@ -23532,6 +26238,8 @@ static BLOCKS_WAXED_COPPER_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_BLOCK_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_BLOCK_POOL0_ENTRIES,
@@ -23550,6 +26258,8 @@ static BLOCKS_WAXED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_BULB_POOL0_ENTRIES,
@@ -23568,6 +26278,8 @@ static BLOCKS_WAXED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -23586,6 +26298,8 @@ static BLOCKS_WAXED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_CHEST_POOL0_ENTRIES,
@@ -23606,6 +26320,8 @@ static BLOCKS_WAXED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_DOOR_POOL0_ENTRIES,
@@ -23624,6 +26340,8 @@ static BLOCKS_WAXED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -23642,6 +26360,8 @@ static BLOCKS_WAXED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_GRATE_POOL0_ENTRIES,
@@ -23660,6 +26380,8 @@ static BLOCKS_WAXED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -23678,6 +26400,8 @@ static BLOCKS_WAXED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -23696,6 +26420,8 @@ static BLOCKS_WAXED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_CUT_COPPER_POOL0_ENTRIES,
@@ -23717,6 +26443,8 @@ static BLOCKS_WAXED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:waxed_cut_copper_slab",
@@ -23727,6 +26455,8 @@ static BLOCKS_WAXED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WAXED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -23746,6 +26476,8 @@ static BLOCKS_WAXED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -23764,6 +26496,8 @@ static BLOCKS_WAXED_EXPOSED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -23782,6 +26516,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_POOL0_ENTRIES,
@@ -23800,6 +26536,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_BARS_POOL0_ENTRIES,
@@ -23818,6 +26556,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_BULB_POOL0_ENTRIES,
@@ -23836,6 +26576,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -23854,6 +26596,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_CHEST_POOL0_ENTRIES,
@@ -23874,6 +26618,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOL0_ENTRIES,
@@ -23892,6 +26638,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -23910,6 +26658,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_GRATE_POOL0_ENTRIES,
@@ -23928,6 +26678,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -23946,6 +26698,8 @@ static BLOCKS_WAXED_EXPOSED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -23964,6 +26718,8 @@ static BLOCKS_WAXED_EXPOSED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_CUT_COPPER_POOL0_ENTRIES,
@@ -23985,6 +26741,8 @@ static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:waxed_exposed_cut_copper_slab",
@@ -23995,6 +26753,8 @@ static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WAXED_EXPOSED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -24014,6 +26774,8 @@ static BLOCKS_WAXED_EXPOSED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[Lo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -24032,6 +26794,8 @@ static BLOCKS_WAXED_EXPOSED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_EXPOSED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_EXPOSED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -24050,6 +26814,8 @@ static BLOCKS_WAXED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -24068,6 +26834,8 @@ static BLOCKS_WAXED_OXIDIZED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[Loo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -24086,6 +26854,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_POOL0_ENTRIES,
@@ -24104,6 +26874,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_BARS_POOL0_ENTRIES,
@@ -24122,6 +26894,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_BULB_POOL0_ENTRIES,
@@ -24140,6 +26914,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -24158,6 +26934,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_CHEST_POOL0_ENTRIES,
@@ -24178,6 +26956,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES,
@@ -24196,6 +26976,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -24214,6 +26996,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_GRATE_POOL0_ENTRIES,
@@ -24232,6 +27016,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -24250,6 +27036,8 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[Loo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -24268,6 +27056,8 @@ static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_CUT_COPPER_POOL0_ENTRIES,
@@ -24289,6 +27079,8 @@ static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:waxed_oxidized_cut_copper_slab",
@@ -24299,6 +27091,8 @@ static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -24318,6 +27112,8 @@ static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[L
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -24336,6 +27132,8 @@ static BLOCKS_WAXED_OXIDIZED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_OXIDIZED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_OXIDIZED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -24354,6 +27152,8 @@ static BLOCKS_WAXED_WEATHERED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[Lo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -24372,6 +27172,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_POOL0_ENTRIES,
@@ -24390,6 +27192,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_BARS_POOL0_ENTRIES,
@@ -24408,6 +27212,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_BULB_POOL0_ENTRIES,
@@ -24426,6 +27232,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -24444,6 +27252,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_CHEST_POOL0_ENTRIES,
@@ -24464,6 +27274,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEn
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOL0_ENTRIES,
@@ -24482,6 +27294,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -24500,6 +27314,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_GRATE_POOL0_ENTRIES,
@@ -24518,6 +27334,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[Loo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -24536,6 +27354,8 @@ static BLOCKS_WAXED_WEATHERED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[Lo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -24554,6 +27374,8 @@ static BLOCKS_WAXED_WEATHERED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_CUT_COPPER_POOL0_ENTRIES,
@@ -24575,6 +27397,8 @@ static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:waxed_weathered_cut_copper_slab",
@@ -24585,6 +27409,8 @@ static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WAXED_WEATHERED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -24604,6 +27430,8 @@ static BLOCKS_WAXED_WEATHERED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -24622,6 +27450,8 @@ static BLOCKS_WAXED_WEATHERED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WAXED_WEATHERED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WAXED_WEATHERED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -24640,6 +27470,8 @@ static BLOCKS_WEATHERED_CHISELED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_CHISELED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_CHISELED_COPPER_POOL0_ENTRIES,
@@ -24658,6 +27490,8 @@ static BLOCKS_WEATHERED_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_POOL0_ENTRIES,
@@ -24676,6 +27510,8 @@ static BLOCKS_WEATHERED_COPPER_BARS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_BARS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_BARS_POOL0_ENTRIES,
@@ -24694,6 +27530,8 @@ static BLOCKS_WEATHERED_COPPER_BULB_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_BULB_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_BULB_POOL0_ENTRIES,
@@ -24712,6 +27550,8 @@ static BLOCKS_WEATHERED_COPPER_CHAIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_CHAIN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_CHAIN_POOL0_ENTRIES,
@@ -24730,6 +27570,8 @@ static BLOCKS_WEATHERED_COPPER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_CHEST_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_CHEST_POOL0_ENTRIES,
@@ -24750,6 +27592,8 @@ static BLOCKS_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("half", "lower")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_DOOR_POOL0_ENTRIES,
@@ -24768,6 +27612,8 @@ static BLOCKS_WEATHERED_COPPER_GOLEM_STATUE_POOL0_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_GOLEM_STATUE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_GOLEM_STATUE_POOL0_ENTRIES,
@@ -24786,6 +27632,8 @@ static BLOCKS_WEATHERED_COPPER_GRATE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_GRATE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_GRATE_POOL0_ENTRIES,
@@ -24804,6 +27652,8 @@ static BLOCKS_WEATHERED_COPPER_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_LANTERN_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_LANTERN_POOL0_ENTRIES,
@@ -24822,6 +27672,8 @@ static BLOCKS_WEATHERED_COPPER_TRAPDOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_COPPER_TRAPDOOR_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_COPPER_TRAPDOOR_POOL0_ENTRIES,
@@ -24840,6 +27692,8 @@ static BLOCKS_WEATHERED_CUT_COPPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_CUT_COPPER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_CUT_COPPER_POOL0_ENTRIES,
@@ -24861,6 +27715,8 @@ static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:weathered_cut_copper_slab",
@@ -24871,6 +27727,8 @@ static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("type", "double")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WEATHERED_CUT_COPPER_SLAB_POOLS: &[LootPool] = &[LootPool {
@@ -24890,6 +27748,8 @@ static BLOCKS_WEATHERED_CUT_COPPER_STAIRS_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_CUT_COPPER_STAIRS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_CUT_COPPER_STAIRS_POOL0_ENTRIES,
@@ -24908,6 +27768,8 @@ static BLOCKS_WEATHERED_LIGHTNING_ROD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WEATHERED_LIGHTNING_ROD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WEATHERED_LIGHTNING_ROD_POOL0_ENTRIES,
@@ -24927,6 +27789,8 @@ static BLOCKS_WEEPING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:weeping_vines",
@@ -24940,6 +27804,8 @@ static BLOCKS_WEEPING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_WEEPING_VINES_POOLS: &[LootPool] = &[LootPool {
@@ -24960,6 +27826,8 @@ static BLOCKS_WEEPING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::SilkTouchOrShears,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:weeping_vines",
@@ -24973,6 +27841,8 @@ static BLOCKS_WEEPING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static BLOCKS_WEEPING_VINES_PLANT_POOLS: &[LootPool] = &[LootPool {
@@ -24992,6 +27862,8 @@ static BLOCKS_WET_SPONGE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WET_SPONGE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WET_SPONGE_POOL0_ENTRIES,
@@ -25013,6 +27885,8 @@ static BLOCKS_WHEAT_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "7")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -25023,6 +27897,8 @@ static BLOCKS_WHEAT_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("age", "7")],
         }),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WHEAT_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -25035,6 +27911,8 @@ static BLOCKS_WHEAT_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
         extra: 3i32,
         probability: 0.5714286f32,
     }),
+    limit: None,
+    explosion_decay: true,
 }];
 static BLOCKS_WHEAT_POOLS: &[LootPool] = &[
     LootPool {
@@ -25064,6 +27942,8 @@ static BLOCKS_WHITE_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_BANNER_POOL0_ENTRIES,
@@ -25084,6 +27964,8 @@ static BLOCKS_WHITE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_BED_POOL0_ENTRIES,
@@ -25105,6 +27987,8 @@ static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:white_candle",
@@ -25120,6 +28004,8 @@ static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:white_candle",
@@ -25138,6 +28024,8 @@ static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:white_candle",
@@ -25156,6 +28044,8 @@ static BLOCKS_WHITE_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WHITE_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -25175,6 +28065,8 @@ static BLOCKS_WHITE_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_CANDLE_CAKE_POOL0_ENTRIES,
@@ -25193,6 +28085,8 @@ static BLOCKS_WHITE_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_CARPET_POOL0_ENTRIES,
@@ -25211,6 +28105,8 @@ static BLOCKS_WHITE_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_CONCRETE_POOL0_ENTRIES,
@@ -25229,6 +28125,8 @@ static BLOCKS_WHITE_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -25247,6 +28145,8 @@ static BLOCKS_WHITE_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -25265,6 +28165,8 @@ static BLOCKS_WHITE_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_SHULKER_BOX_POOL0_ENTRIES,
@@ -25283,6 +28185,8 @@ static BLOCKS_WHITE_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_STAINED_GLASS_POOL0_ENTRIES,
@@ -25301,6 +28205,8 @@ static BLOCKS_WHITE_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -25319,6 +28225,8 @@ static BLOCKS_WHITE_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_TERRACOTTA_POOL0_ENTRIES,
@@ -25337,6 +28245,8 @@ static BLOCKS_WHITE_TULIP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_TULIP_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_TULIP_POOL0_ENTRIES,
@@ -25355,6 +28265,8 @@ static BLOCKS_WHITE_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WHITE_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WHITE_WOOL_POOL0_ENTRIES,
@@ -25376,6 +28288,8 @@ static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("flower_amount", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:wildflowers",
@@ -25391,6 +28305,8 @@ static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:wildflowers",
@@ -25409,6 +28325,8 @@ static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:wildflowers",
@@ -25430,6 +28348,8 @@ static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:wildflowers",
@@ -25451,6 +28371,8 @@ static BLOCKS_WILDFLOWERS_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_WILDFLOWERS_POOLS: &[LootPool] = &[LootPool {
@@ -25470,6 +28392,8 @@ static BLOCKS_WITHER_ROSE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WITHER_ROSE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WITHER_ROSE_POOL0_ENTRIES,
@@ -25488,6 +28412,8 @@ static BLOCKS_WITHER_SKELETON_SKULL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_WITHER_SKELETON_SKULL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_WITHER_SKELETON_SKULL_POOL0_ENTRIES,
@@ -25506,6 +28432,8 @@ static BLOCKS_YELLOW_BANNER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_BANNER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_BANNER_POOL0_ENTRIES,
@@ -25526,6 +28454,8 @@ static BLOCKS_YELLOW_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("part", "head")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_BED_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_BED_POOL0_ENTRIES,
@@ -25547,6 +28477,8 @@ static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             properties: &[("candles", "4")],
         },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:yellow_candle",
@@ -25562,6 +28494,8 @@ static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:yellow_candle",
@@ -25580,6 +28514,8 @@ static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
     LootEntry {
         item: "minecraft:yellow_candle",
@@ -25598,6 +28534,8 @@ static BLOCKS_YELLOW_CANDLE_POOL0_ENTRIES: &[LootEntry] = &[
             }),
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: true,
     },
 ];
 static BLOCKS_YELLOW_CANDLE_POOLS: &[LootPool] = &[LootPool {
@@ -25617,6 +28555,8 @@ static BLOCKS_YELLOW_CANDLE_CAKE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_CANDLE_CAKE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_CANDLE_CAKE_POOL0_ENTRIES,
@@ -25635,6 +28575,8 @@ static BLOCKS_YELLOW_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_CARPET_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_CARPET_POOL0_ENTRIES,
@@ -25653,6 +28595,8 @@ static BLOCKS_YELLOW_CONCRETE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_CONCRETE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_CONCRETE_POOL0_ENTRIES,
@@ -25671,6 +28615,8 @@ static BLOCKS_YELLOW_CONCRETE_POWDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_CONCRETE_POWDER_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_CONCRETE_POWDER_POOL0_ENTRIES,
@@ -25689,6 +28635,8 @@ static BLOCKS_YELLOW_GLAZED_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_GLAZED_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_GLAZED_TERRACOTTA_POOL0_ENTRIES,
@@ -25707,6 +28655,8 @@ static BLOCKS_YELLOW_SHULKER_BOX_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_SHULKER_BOX_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_SHULKER_BOX_POOL0_ENTRIES,
@@ -25725,6 +28675,8 @@ static BLOCKS_YELLOW_STAINED_GLASS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_STAINED_GLASS_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_STAINED_GLASS_POOL0_ENTRIES,
@@ -25743,6 +28695,8 @@ static BLOCKS_YELLOW_STAINED_GLASS_PANE_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_STAINED_GLASS_PANE_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_STAINED_GLASS_PANE_POOL0_ENTRIES,
@@ -25761,6 +28715,8 @@ static BLOCKS_YELLOW_TERRACOTTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_TERRACOTTA_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_TERRACOTTA_POOL0_ENTRIES,
@@ -25779,6 +28735,8 @@ static BLOCKS_YELLOW_WOOL_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_YELLOW_WOOL_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_YELLOW_WOOL_POOL0_ENTRIES,
@@ -25797,6 +28755,8 @@ static BLOCKS_ZOMBIE_HEAD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BLOCKS_ZOMBIE_HEAD_POOLS: &[LootPool] = &[LootPool {
     entries: BLOCKS_ZOMBIE_HEAD_POOL0_ENTRIES,
@@ -25815,6 +28775,8 @@ static BRUSH_ARMADILLO_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static BRUSH_ARMADILLO_POOLS: &[LootPool] = &[LootPool {
     entries: BRUSH_ARMADILLO_POOL0_ENTRIES,
@@ -25833,6 +28795,8 @@ static CARVE_PUMPKIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 4i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CARVE_PUMPKIN_POOLS: &[LootPool] = &[LootPool {
     entries: CARVE_PUMPKIN_POOL0_ENTRIES,
@@ -25851,6 +28815,8 @@ static CHARGED_CREEPER_CREEPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHARGED_CREEPER_CREEPER_POOLS: &[LootPool] = &[LootPool {
     entries: CHARGED_CREEPER_CREEPER_POOL0_ENTRIES,
@@ -25869,6 +28835,8 @@ static CHARGED_CREEPER_PIGLIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHARGED_CREEPER_PIGLIN_POOLS: &[LootPool] = &[LootPool {
     entries: CHARGED_CREEPER_PIGLIN_POOL0_ENTRIES,
@@ -25888,6 +28856,8 @@ static CHARGED_CREEPER_ROOT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:creeper_head",
@@ -25896,6 +28866,8 @@ static CHARGED_CREEPER_ROOT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:skeleton_skull",
@@ -25904,6 +28876,8 @@ static CHARGED_CREEPER_ROOT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wither_skeleton_skull",
@@ -25912,6 +28886,8 @@ static CHARGED_CREEPER_ROOT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:zombie_head",
@@ -25920,6 +28896,8 @@ static CHARGED_CREEPER_ROOT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHARGED_CREEPER_ROOT_POOLS: &[LootPool] = &[LootPool {
@@ -25939,6 +28917,8 @@ static CHARGED_CREEPER_SKELETON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHARGED_CREEPER_SKELETON_POOLS: &[LootPool] = &[LootPool {
     entries: CHARGED_CREEPER_SKELETON_POOL0_ENTRIES,
@@ -25957,6 +28937,8 @@ static CHARGED_CREEPER_WITHER_SKELETON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHARGED_CREEPER_WITHER_SKELETON_POOLS: &[LootPool] = &[LootPool {
     entries: CHARGED_CREEPER_WITHER_SKELETON_POOL0_ENTRIES,
@@ -25975,6 +28957,8 @@ static CHARGED_CREEPER_ZOMBIE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHARGED_CREEPER_ZOMBIE_POOLS: &[LootPool] = &[LootPool {
     entries: CHARGED_CREEPER_ZOMBIE_POOL0_ENTRIES,
@@ -25994,6 +28978,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -26002,6 +28988,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:name_tag",
@@ -26010,6 +28998,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -26018,6 +29008,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -26026,6 +29018,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
@@ -26036,6 +29030,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -26044,6 +29040,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -26052,6 +29050,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -26060,6 +29060,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -26068,6 +29070,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -26076,6 +29080,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -26084,6 +29090,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glow_berries",
@@ -26092,6 +29100,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -26100,6 +29110,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -26108,6 +29120,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -26116,6 +29130,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
@@ -26126,6 +29142,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:powered_rail",
@@ -26134,6 +29152,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:detector_rail",
@@ -26142,6 +29162,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:activator_rail",
@@ -26150,6 +29172,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:torch",
@@ -26158,6 +29182,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 16i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_bounce",
@@ -26166,6 +29192,8 @@ static CHESTS_ABANDONED_MINESHAFT_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ABANDONED_MINESHAFT_POOLS: &[LootPool] = &[
@@ -26202,6 +29230,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_otherside",
@@ -26210,6 +29240,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:compass",
@@ -26218,6 +29250,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sculk_catalyst",
@@ -26226,6 +29260,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_hoe",
@@ -26234,6 +29270,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lead",
@@ -26242,6 +29280,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -26250,6 +29290,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -26258,6 +29300,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_13",
@@ -26266,6 +29310,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_cat",
@@ -26274,6 +29320,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_leggings",
@@ -26282,6 +29330,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -26290,6 +29340,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sculk",
@@ -26298,6 +29350,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sculk_sensor",
@@ -26306,6 +29360,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:candle",
@@ -26314,6 +29370,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:amethyst_shard",
@@ -26322,6 +29380,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:experience_bottle",
@@ -26330,6 +29390,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glow_berries",
@@ -26338,6 +29400,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_leggings",
@@ -26346,6 +29410,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:echo_shard",
@@ -26354,6 +29420,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:disc_fragment_5",
@@ -26362,6 +29430,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -26370,6 +29440,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -26378,6 +29450,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -26386,6 +29460,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone",
@@ -26394,6 +29470,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:soul_torch",
@@ -26402,6 +29480,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -26410,6 +29490,8 @@ static CHESTS_ANCIENT_CITY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ANCIENT_CITY_POOL1_ENTRIES: &[LootEntry] = &[
@@ -26420,6 +29502,8 @@ static CHESTS_ANCIENT_CITY_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:silence_armor_trim_smithing_template",
@@ -26428,6 +29512,8 @@ static CHESTS_ANCIENT_CITY_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ANCIENT_CITY_POOLS: &[LootPool] = &[
@@ -26457,6 +29543,8 @@ static CHESTS_ANCIENT_CITY_ICE_BOX_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -26465,6 +29553,8 @@ static CHESTS_ANCIENT_CITY_ICE_BOX_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -26473,6 +29563,8 @@ static CHESTS_ANCIENT_CITY_ICE_BOX_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:packed_ice",
@@ -26481,6 +29573,8 @@ static CHESTS_ANCIENT_CITY_ICE_BOX_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -26489,6 +29583,8 @@ static CHESTS_ANCIENT_CITY_ICE_BOX_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_ANCIENT_CITY_ICE_BOX_POOLS: &[LootPool] = &[LootPool {
@@ -26508,6 +29604,8 @@ static CHESTS_BASTION_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -26517,6 +29615,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spectral_arrow",
@@ -26525,6 +29625,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 28i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gilded_blackstone",
@@ -26533,6 +29635,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crying_obsidian",
@@ -26541,6 +29645,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_block",
@@ -26549,6 +29655,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -26557,6 +29665,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -26565,6 +29675,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_sword",
@@ -26573,6 +29685,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_chestplate",
@@ -26581,6 +29695,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_helmet",
@@ -26589,6 +29705,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_leggings",
@@ -26597,6 +29715,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_boots",
@@ -26605,6 +29725,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_axe",
@@ -26613,6 +29735,8 @@ static CHESTS_BASTION_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
@@ -26623,6 +29747,8 @@ static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -26631,6 +29757,8 @@ static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -26639,6 +29767,8 @@ static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 17i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nugget",
@@ -26647,6 +29777,8 @@ static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -26655,6 +29787,8 @@ static CHESTS_BASTION_BRIDGE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_BRIDGE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -26664,6 +29798,8 @@ static CHESTS_BASTION_BRIDGE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_BRIDGE_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:netherite_upgrade_smithing_template",
@@ -26672,6 +29808,8 @@ static CHESTS_BASTION_BRIDGE_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_BRIDGE_POOLS: &[LootPool] = &[
     LootPool {
@@ -26721,6 +29859,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_pickaxe",
@@ -26729,6 +29869,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:netherite_scrap",
@@ -26737,6 +29879,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ancient_debris",
@@ -26745,6 +29889,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ancient_debris",
@@ -26753,6 +29899,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -26761,6 +29909,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_block",
@@ -26769,6 +29919,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -26777,6 +29929,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 17i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -26785,6 +29939,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
@@ -26795,6 +29951,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crying_obsidian",
@@ -26803,6 +29961,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glowstone",
@@ -26811,6 +29971,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gilded_blackstone",
@@ -26819,6 +29981,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:soul_sand",
@@ -26827,6 +29991,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crimson_nylium",
@@ -26835,6 +30001,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -26843,6 +30011,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -26851,6 +30021,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -26859,6 +30031,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 17i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -26867,6 +30041,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:porkchop",
@@ -26875,6 +30051,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_porkchop",
@@ -26883,6 +30061,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crimson_fungus",
@@ -26891,6 +30071,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crimson_roots",
@@ -26899,6 +30081,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_HOGLIN_STABLE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -26908,6 +30092,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_HOGLIN_STABLE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:netherite_upgrade_smithing_template",
@@ -26916,6 +30102,8 @@ static CHESTS_BASTION_HOGLIN_STABLE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_HOGLIN_STABLE_POOLS: &[LootPool] = &[
     LootPool {
@@ -26958,6 +30146,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_shovel",
@@ -26966,6 +30156,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -26974,6 +30166,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ancient_debris",
@@ -26982,6 +30176,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:netherite_scrap",
@@ -26990,6 +30186,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spectral_arrow",
@@ -26998,6 +30196,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 22i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:piglin_banner_pattern",
@@ -27006,6 +30206,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_pigstep",
@@ -27014,6 +30216,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -27022,6 +30226,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 17i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -27030,6 +30236,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -27038,6 +30246,8 @@ static CHESTS_BASTION_OTHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
@@ -27048,6 +30258,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_block",
@@ -27056,6 +30268,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_boots",
@@ -27064,6 +30278,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_axe",
@@ -27072,6 +30288,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_block",
@@ -27080,6 +30298,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -27088,6 +30308,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -27096,6 +30318,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -27104,6 +30328,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_sword",
@@ -27112,6 +30338,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_chestplate",
@@ -27120,6 +30348,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_helmet",
@@ -27128,6 +30358,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_leggings",
@@ -27136,6 +30368,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_boots",
@@ -27144,6 +30378,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crying_obsidian",
@@ -27152,6 +30388,8 @@ static CHESTS_BASTION_OTHER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
@@ -27162,6 +30400,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chain",
@@ -27170,6 +30410,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magma_cream",
@@ -27178,6 +30420,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone_block",
@@ -27186,6 +30430,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nugget",
@@ -27194,6 +30440,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:obsidian",
@@ -27202,6 +30450,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -27210,6 +30460,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -27218,6 +30470,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -27226,6 +30480,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 17i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_porkchop",
@@ -27234,6 +30490,8 @@ static CHESTS_BASTION_OTHER_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_OTHER_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -27243,6 +30501,8 @@ static CHESTS_BASTION_OTHER_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_OTHER_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:netherite_upgrade_smithing_template",
@@ -27251,6 +30511,8 @@ static CHESTS_BASTION_OTHER_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_OTHER_POOLS: &[LootPool] = &[
     LootPool {
@@ -27300,6 +30562,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ancient_debris",
@@ -27308,6 +30572,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:netherite_scrap",
@@ -27316,6 +30582,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ancient_debris",
@@ -27324,6 +30592,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_sword",
@@ -27332,6 +30602,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_spear",
@@ -27340,6 +30612,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -27348,6 +30622,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -27356,6 +30632,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_leggings",
@@ -27364,6 +30642,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_boots",
@@ -27372,6 +30652,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_sword",
@@ -27380,6 +30662,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_spear",
@@ -27388,6 +30672,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -27396,6 +30682,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -27404,6 +30692,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_boots",
@@ -27412,6 +30702,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_leggings",
@@ -27420,6 +30712,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -27428,6 +30722,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -27436,6 +30732,8 @@ static CHESTS_BASTION_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
@@ -27446,6 +30744,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 25i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_block",
@@ -27454,6 +30754,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_block",
@@ -27462,6 +30764,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -27470,6 +30774,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -27478,6 +30784,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crying_obsidian",
@@ -27486,6 +30794,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:quartz",
@@ -27494,6 +30804,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 23i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gilded_blackstone",
@@ -27502,6 +30814,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magma_cream",
@@ -27510,6 +30824,8 @@ static CHESTS_BASTION_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BASTION_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -27519,6 +30835,8 @@ static CHESTS_BASTION_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:netherite_upgrade_smithing_template",
@@ -27527,6 +30845,8 @@ static CHESTS_BASTION_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BASTION_TREASURE_POOLS: &[LootPool] = &[
     LootPool {
@@ -27568,6 +30888,8 @@ static CHESTS_BURIED_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BURIED_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -27577,6 +30899,8 @@ static CHESTS_BURIED_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -27585,6 +30909,8 @@ static CHESTS_BURIED_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tnt",
@@ -27593,6 +30919,8 @@ static CHESTS_BURIED_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BURIED_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[
@@ -27603,6 +30931,8 @@ static CHESTS_BURIED_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -27611,6 +30941,8 @@ static CHESTS_BURIED_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:prismarine_crystals",
@@ -27619,6 +30951,8 @@ static CHESTS_BURIED_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BURIED_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
@@ -27629,6 +30963,8 @@ static CHESTS_BURIED_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -27637,6 +30973,8 @@ static CHESTS_BURIED_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_spear",
@@ -27645,6 +30983,8 @@ static CHESTS_BURIED_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BURIED_TREASURE_POOL4_ENTRIES: &[LootEntry] = &[
@@ -27655,6 +30995,8 @@ static CHESTS_BURIED_TREASURE_POOL4_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_salmon",
@@ -27663,6 +31005,8 @@ static CHESTS_BURIED_TREASURE_POOL4_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BURIED_TREASURE_POOL5_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -27672,6 +31016,8 @@ static CHESTS_BURIED_TREASURE_POOL5_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_BURIED_TREASURE_POOL6_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -27681,6 +31027,8 @@ static CHESTS_BURIED_TREASURE_POOL6_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -27689,6 +31037,8 @@ static CHESTS_BURIED_TREASURE_POOL6_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -27697,6 +31047,8 @@ static CHESTS_BURIED_TREASURE_POOL6_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -27705,6 +31057,8 @@ static CHESTS_BURIED_TREASURE_POOL6_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_BURIED_TREASURE_POOLS: &[LootPool] = &[
@@ -27769,6 +31123,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -27777,6 +31133,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -27785,6 +31143,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -27793,6 +31153,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone",
@@ -27801,6 +31163,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spider_eye",
@@ -27809,6 +31173,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -27817,6 +31183,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -27825,6 +31193,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -27833,6 +31203,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -27841,6 +31213,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -27849,6 +31223,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -27857,6 +31233,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -27865,6 +31243,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -27873,6 +31253,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -27881,6 +31263,8 @@ static CHESTS_DESERT_PYRAMID_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
@@ -27891,6 +31275,8 @@ static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -27899,6 +31285,8 @@ static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -27907,6 +31295,8 @@ static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -27915,6 +31305,8 @@ static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sand",
@@ -27923,6 +31315,8 @@ static CHESTS_DESERT_PYRAMID_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_DESERT_PYRAMID_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -27932,6 +31326,8 @@ static CHESTS_DESERT_PYRAMID_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_DESERT_PYRAMID_POOLS: &[LootPool] = &[
     LootPool {
@@ -27967,6 +31363,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -27975,6 +31373,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -27983,6 +31383,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -27991,6 +31393,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -27999,6 +31403,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -28007,6 +31413,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -28015,6 +31423,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -28023,6 +31433,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -28031,6 +31443,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -28039,6 +31453,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_sword",
@@ -28047,6 +31463,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_spear",
@@ -28055,6 +31473,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_boots",
@@ -28063,6 +31483,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -28071,6 +31493,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_leggings",
@@ -28079,6 +31503,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -28087,6 +31513,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_pickaxe",
@@ -28095,6 +31523,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_shovel",
@@ -28103,6 +31533,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -28111,6 +31543,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_boots",
@@ -28119,6 +31553,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -28127,6 +31563,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_leggings",
@@ -28135,6 +31573,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -28143,6 +31583,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -28151,6 +31593,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_shovel",
@@ -28159,6 +31603,8 @@ static CHESTS_END_CITY_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_END_CITY_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28168,6 +31614,8 @@ static CHESTS_END_CITY_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_END_CITY_TREASURE_POOLS: &[LootPool] = &[
     LootPool {
@@ -28196,6 +31644,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -28204,6 +31654,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -28212,6 +31664,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_axe",
@@ -28220,6 +31674,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -28228,6 +31684,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -28236,6 +31694,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -28244,6 +31704,8 @@ static CHESTS_IGLOO_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_IGLOO_CHEST_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28253,6 +31715,8 @@ static CHESTS_IGLOO_CHEST_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_IGLOO_CHEST_POOLS: &[LootPool] = &[
     LootPool {
@@ -28281,6 +31745,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -28289,6 +31755,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -28297,6 +31765,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo",
@@ -28305,6 +31775,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -28313,6 +31785,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone",
@@ -28321,6 +31795,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -28329,6 +31805,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -28337,6 +31815,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -28345,6 +31825,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -28353,6 +31835,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -28361,6 +31845,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -28369,6 +31855,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -28377,6 +31865,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_JUNGLE_TEMPLE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28386,6 +31876,8 @@ static CHESTS_JUNGLE_TEMPLE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_JUNGLE_TEMPLE_POOLS: &[LootPool] = &[
     LootPool {
@@ -28413,6 +31905,8 @@ static CHESTS_JUNGLE_TEMPLE_DISPENSER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 7i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_JUNGLE_TEMPLE_DISPENSER_POOLS: &[LootPool] = &[LootPool {
     entries: CHESTS_JUNGLE_TEMPLE_DISPENSER_POOL0_ENTRIES,
@@ -28432,6 +31926,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -28440,6 +31936,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -28448,6 +31946,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_sword",
@@ -28456,6 +31956,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_chestplate",
@@ -28464,6 +31966,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flint_and_steel",
@@ -28472,6 +31976,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:nether_wart",
@@ -28480,6 +31986,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -28488,6 +31996,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -28496,6 +32006,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -28504,6 +32016,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -28512,6 +32026,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -28520,6 +32036,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:obsidian",
@@ -28528,6 +32046,8 @@ static CHESTS_NETHER_BRIDGE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_NETHER_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28537,6 +32057,8 @@ static CHESTS_NETHER_BRIDGE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_NETHER_BRIDGE_POOLS: &[LootPool] = &[
     LootPool {
@@ -28564,6 +32086,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_PILLAGER_OUTPOST_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -28573,6 +32097,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -28581,6 +32107,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:carrot",
@@ -28589,6 +32117,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_PILLAGER_OUTPOST_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28598,6 +32128,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -28607,6 +32139,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -28615,6 +32149,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -28623,6 +32159,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tripwire_hook",
@@ -28631,6 +32169,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -28639,6 +32179,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -28647,6 +32189,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_PILLAGER_OUTPOST_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28656,6 +32200,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_PILLAGER_OUTPOST_POOL5_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sentry_armor_trim_smithing_template",
@@ -28664,6 +32210,8 @@ static CHESTS_PILLAGER_OUTPOST_POOL5_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_PILLAGER_OUTPOST_POOLS: &[LootPool] = &[
     LootPool {
@@ -28720,6 +32268,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flint",
@@ -28728,6 +32278,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nugget",
@@ -28736,6 +32288,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 18i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flint_and_steel",
@@ -28744,6 +32298,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fire_charge",
@@ -28752,6 +32308,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -28760,6 +32318,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -28768,6 +32328,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 24i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_sword",
@@ -28776,6 +32338,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_axe",
@@ -28784,6 +32348,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_hoe",
@@ -28792,6 +32358,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_shovel",
@@ -28800,6 +32368,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_pickaxe",
@@ -28808,6 +32378,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_boots",
@@ -28816,6 +32388,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_chestplate",
@@ -28824,6 +32398,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_helmet",
@@ -28832,6 +32408,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_leggings",
@@ -28840,6 +32418,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glistering_melon_slice",
@@ -28848,6 +32428,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -28856,6 +32438,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_weighted_pressure_plate",
@@ -28864,6 +32448,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -28872,6 +32458,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:clock",
@@ -28880,6 +32468,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -28888,6 +32478,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bell",
@@ -28896,6 +32488,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -28904,6 +32498,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_block",
@@ -28912,6 +32508,8 @@ static CHESTS_RUINED_PORTAL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_RUINED_PORTAL_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -28921,6 +32519,8 @@ static CHESTS_RUINED_PORTAL_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_RUINED_PORTAL_POOLS: &[LootPool] = &[
     LootPool {
@@ -28948,6 +32548,8 @@ static CHESTS_SHIPWRECK_MAP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -28957,6 +32559,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:map",
@@ -28965,6 +32569,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:clock",
@@ -28973,6 +32579,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:paper",
@@ -28981,6 +32589,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:feather",
@@ -28989,6 +32599,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -28997,6 +32609,8 @@ static CHESTS_SHIPWRECK_MAP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_MAP_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -29006,6 +32620,8 @@ static CHESTS_SHIPWRECK_MAP_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_SHIPWRECK_MAP_POOL3_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -29015,6 +32631,8 @@ static CHESTS_SHIPWRECK_MAP_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -29023,6 +32641,8 @@ static CHESTS_SHIPWRECK_MAP_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -29031,6 +32651,8 @@ static CHESTS_SHIPWRECK_MAP_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -29039,6 +32661,8 @@ static CHESTS_SHIPWRECK_MAP_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_MAP_POOLS: &[LootPool] = &[
@@ -29082,6 +32706,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -29090,6 +32716,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:moss_block",
@@ -29098,6 +32726,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:poisonous_potato",
@@ -29106,6 +32736,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:carrot",
@@ -29114,6 +32746,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -29122,6 +32756,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 21i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:suspicious_stew",
@@ -29130,6 +32766,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -29138,6 +32776,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -29146,6 +32786,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 24i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin",
@@ -29154,6 +32796,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo",
@@ -29162,6 +32806,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -29170,6 +32816,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tnt",
@@ -29178,6 +32826,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_helmet",
@@ -29186,6 +32836,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_chestplate",
@@ -29194,6 +32846,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_leggings",
@@ -29202,6 +32856,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_boots",
@@ -29210,6 +32866,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_SUPPLY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -29219,6 +32877,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_SHIPWRECK_SUPPLY_POOL2_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -29228,6 +32888,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -29236,6 +32898,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -29244,6 +32908,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -29252,6 +32918,8 @@ static CHESTS_SHIPWRECK_SUPPLY_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_SUPPLY_POOLS: &[LootPool] = &[
@@ -29288,6 +32956,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -29296,6 +32966,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -29304,6 +32976,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -29312,6 +32986,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:experience_bottle",
@@ -29320,6 +32996,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
@@ -29330,6 +33008,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -29338,6 +33018,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -29346,6 +33028,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -29355,6 +33039,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_SHIPWRECK_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -29364,6 +33050,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -29372,6 +33060,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -29380,6 +33070,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -29388,6 +33080,8 @@ static CHESTS_SHIPWRECK_TREASURE_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SHIPWRECK_TREASURE_POOLS: &[LootPool] = &[
@@ -29431,6 +33125,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -29439,6 +33135,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -29447,6 +33145,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_otherside",
@@ -29455,6 +33155,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_13",
@@ -29463,6 +33165,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_cat",
@@ -29471,6 +33175,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:name_tag",
@@ -29479,6 +33185,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -29487,6 +33195,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -29495,6 +33205,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -29503,6 +33215,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -29511,6 +33225,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -29519,6 +33235,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
@@ -29529,6 +33247,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -29537,6 +33257,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -29545,6 +33267,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -29553,6 +33277,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bucket",
@@ -29561,6 +33287,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -29569,6 +33297,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -29577,6 +33307,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -29585,6 +33317,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -29593,6 +33327,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -29601,6 +33337,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SIMPLE_DUNGEON_POOL2_ENTRIES: &[LootEntry] = &[
@@ -29611,6 +33349,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -29619,6 +33359,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -29627,6 +33369,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -29635,6 +33379,8 @@ static CHESTS_SIMPLE_DUNGEON_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SIMPLE_DUNGEON_POOLS: &[LootPool] = &[
@@ -29671,6 +33417,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_axe",
@@ -29679,6 +33427,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SPAWN_BONUS_CHEST_POOL1_ENTRIES: &[LootEntry] = &[
@@ -29689,6 +33439,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_pickaxe",
@@ -29697,6 +33449,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SPAWN_BONUS_CHEST_POOL2_ENTRIES: &[LootEntry] = &[
@@ -29707,6 +33461,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -29715,6 +33471,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -29723,6 +33481,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
@@ -29733,6 +33493,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_planks",
@@ -29741,6 +33503,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_log",
@@ -29749,6 +33513,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_log",
@@ -29757,6 +33523,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:birch_log",
@@ -29765,6 +33533,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:jungle_log",
@@ -29773,6 +33543,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:acacia_log",
@@ -29781,6 +33553,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dark_oak_log",
@@ -29789,6 +33563,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:mangrove_log",
@@ -29797,6 +33573,8 @@ static CHESTS_SPAWN_BONUS_CHEST_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_SPAWN_BONUS_CHEST_POOLS: &[LootPool] = &[
@@ -29840,6 +33618,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -29848,6 +33628,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -29856,6 +33638,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -29864,6 +33648,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -29872,6 +33658,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -29880,6 +33668,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:apple",
@@ -29888,6 +33678,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -29896,6 +33688,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -29904,6 +33698,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -29912,6 +33708,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -29920,6 +33718,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_leggings",
@@ -29928,6 +33728,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_boots",
@@ -29936,6 +33738,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -29944,6 +33748,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -29952,6 +33758,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -29960,6 +33768,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -29968,6 +33778,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -29976,6 +33788,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -29984,6 +33798,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_otherside",
@@ -29992,6 +33808,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30000,6 +33818,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_STRONGHOLD_CORRIDOR_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -30009,6 +33829,8 @@ static CHESTS_STRONGHOLD_CORRIDOR_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_STRONGHOLD_CORRIDOR_POOLS: &[LootPool] = &[
     LootPool {
@@ -30037,6 +33859,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -30045,6 +33869,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -30053,6 +33879,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -30061,6 +33889,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -30069,6 +33899,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:apple",
@@ -30077,6 +33909,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -30085,6 +33919,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30093,6 +33929,8 @@ static CHESTS_STRONGHOLD_CROSSING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_STRONGHOLD_CROSSING_POOLS: &[LootPool] = &[LootPool {
@@ -30113,6 +33951,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:paper",
@@ -30121,6 +33961,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:map",
@@ -30129,6 +33971,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:compass",
@@ -30137,6 +33981,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30145,6 +33991,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_STRONGHOLD_LIBRARY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -30154,6 +34002,8 @@ static CHESTS_STRONGHOLD_LIBRARY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_STRONGHOLD_LIBRARY_POOLS: &[LootPool] = &[
     LootPool {
@@ -30182,6 +34032,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:honeycomb",
@@ -30190,6 +34042,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_axe",
@@ -30198,6 +34052,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_pickaxe",
@@ -30206,6 +34062,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ender_pearl",
@@ -30214,6 +34072,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo_hanging_sign",
@@ -30222,6 +34082,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo_planks",
@@ -30230,6 +34092,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:scaffolding",
@@ -30238,6 +34102,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:torch",
@@ -30246,6 +34112,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tuff",
@@ -30254,6 +34122,8 @@ static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 20i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_CORRIDOR_POOLS: &[LootPool] = &[LootPool {
@@ -30274,6 +34144,8 @@ static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -30282,6 +34154,8 @@ static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wooden_axe",
@@ -30290,6 +34164,8 @@ static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:honeycomb",
@@ -30298,6 +34174,8 @@ static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -30306,6 +34184,8 @@ static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_ENTRANCE_POOLS: &[LootPool] = &[LootPool {
@@ -30326,6 +34206,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald_block",
@@ -30334,6 +34216,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_axe",
@@ -30342,6 +34226,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_pickaxe",
@@ -30350,6 +34236,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30358,6 +34246,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cake",
@@ -30366,6 +34256,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:amethyst_shard",
@@ -30374,6 +34266,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 20i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_block",
@@ -30382,6 +34276,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_INTERSECTION_POOLS: &[LootPool] = &[LootPool {
@@ -30402,6 +34298,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_pickaxe",
@@ -30410,6 +34308,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30418,6 +34318,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:compass",
@@ -30426,6 +34328,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bucket",
@@ -30434,6 +34338,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_axe",
@@ -30442,6 +34348,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_pickaxe",
@@ -30450,6 +34358,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo_planks",
@@ -30458,6 +34368,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 15i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -30466,6 +34378,8 @@ static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_INTERSECTION_BARREL_POOLS: &[LootPool] = &[LootPool {
@@ -30486,6 +34400,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:shield",
@@ -30494,6 +34410,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -30502,6 +34420,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -30510,6 +34430,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_axe",
@@ -30518,6 +34440,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -30526,6 +34450,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -30534,6 +34460,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30542,6 +34470,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30550,6 +34480,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -30558,6 +34490,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_axe",
@@ -30566,6 +34500,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -30574,6 +34510,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -30582,6 +34520,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -30590,6 +34530,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30598,6 +34540,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -30606,6 +34550,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:honey_bottle",
@@ -30614,6 +34560,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -30622,6 +34570,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30630,6 +34580,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30638,6 +34590,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
@@ -30648,6 +34602,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -30656,6 +34612,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -30664,6 +34622,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30672,6 +34632,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -30680,6 +34642,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:honey_bottle",
@@ -30688,6 +34652,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -30696,6 +34662,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30704,6 +34672,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30712,6 +34682,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
@@ -30722,6 +34694,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bolt_armor_trim_smithing_template",
@@ -30730,6 +34704,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:guster_banner_pattern",
@@ -30738,6 +34714,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_precipice",
@@ -30746,6 +34724,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:trident",
@@ -30754,6 +34734,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_POOLS: &[LootPool] = &[
@@ -30790,6 +34772,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -30798,6 +34782,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -30806,6 +34792,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30814,6 +34802,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -30822,6 +34812,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:honey_bottle",
@@ -30830,6 +34822,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -30838,6 +34832,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30846,6 +34842,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30854,6 +34852,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_COMMON_POOLS: &[LootPool] = &[LootPool {
@@ -30874,6 +34874,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_block",
@@ -30882,6 +34884,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -30890,6 +34894,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -30898,6 +34904,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_axe",
@@ -30906,6 +34914,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -30914,6 +34924,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30922,6 +34934,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30930,6 +34944,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -30938,6 +34954,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_block",
@@ -30946,6 +34964,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -30954,6 +34974,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -30962,6 +34984,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -30970,6 +34994,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -30978,6 +35004,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -30986,6 +35014,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
@@ -30996,6 +35026,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -31004,6 +35036,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -31012,6 +35046,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -31020,6 +35056,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -31028,6 +35066,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
@@ -31038,6 +35078,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flow_armor_trim_smithing_template",
@@ -31046,6 +35088,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flow_banner_pattern",
@@ -31054,6 +35098,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_creator",
@@ -31062,6 +35108,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:heavy_core",
@@ -31070,6 +35118,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_POOLS: &[LootPool] = &[
@@ -31106,6 +35156,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOL0_ENTRIES: &[LootEntry] =
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -31114,6 +35166,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOL0_ENTRIES: &[LootEntry] =
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -31122,6 +35176,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOL0_ENTRIES: &[LootEntry] =
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -31130,6 +35186,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOL0_ENTRIES: &[LootEntry] =
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ominous_bottle",
@@ -31138,6 +35196,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_COMMON_POOLS: &[LootPool] = &[LootPool {
@@ -31158,6 +35218,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_block",
@@ -31166,6 +35228,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -31174,6 +35238,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -31182,6 +35248,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_axe",
@@ -31190,6 +35258,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -31198,6 +35268,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31206,6 +35278,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31214,6 +35288,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31222,6 +35298,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_block",
@@ -31230,6 +35308,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_RARE_POOLS: &[LootPool] = &[LootPool {
@@ -31250,6 +35330,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flow_armor_trim_smithing_template",
@@ -31258,6 +35340,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flow_banner_pattern",
@@ -31266,6 +35350,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_creator",
@@ -31274,6 +35360,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:heavy_core",
@@ -31282,6 +35370,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_OMINOUS_UNIQUE_POOLS: &[LootPool] = &[LootPool {
@@ -31302,6 +35392,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:shield",
@@ -31310,6 +35402,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -31318,6 +35412,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crossbow",
@@ -31326,6 +35422,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_axe",
@@ -31334,6 +35432,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -31342,6 +35442,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -31350,6 +35452,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31358,6 +35462,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31366,6 +35472,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -31374,6 +35482,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_axe",
@@ -31382,6 +35492,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_RARE_POOLS: &[LootPool] = &[LootPool {
@@ -31402,6 +35514,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bolt_armor_trim_smithing_template",
@@ -31410,6 +35524,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:guster_banner_pattern",
@@ -31418,6 +35534,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_precipice",
@@ -31426,6 +35544,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:trident",
@@ -31434,6 +35554,8 @@ static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_REWARD_UNIQUE_POOLS: &[LootPool] = &[LootPool {
@@ -31454,6 +35576,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 14i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -31462,6 +35586,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -31470,6 +35596,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -31478,6 +35606,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glow_berries",
@@ -31486,6 +35616,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:acacia_planks",
@@ -31494,6 +35626,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:moss_block",
@@ -31502,6 +35636,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone_meal",
@@ -31510,6 +35646,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tuff",
@@ -31518,6 +35656,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:torch",
@@ -31526,6 +35666,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -31534,6 +35676,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -31542,6 +35686,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_pickaxe",
@@ -31550,6 +35696,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:milk_bucket",
@@ -31558,6 +35706,8 @@ static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_TRIAL_CHAMBERS_SUPPLY_POOLS: &[LootPool] = &[LootPool {
@@ -31578,6 +35728,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_nugget",
@@ -31586,6 +35738,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -31594,6 +35748,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_spear",
@@ -31602,6 +35758,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -31610,6 +35768,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
@@ -31620,6 +35780,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -31628,6 +35790,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_chestplate",
@@ -31636,6 +35800,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_helmet",
@@ -31644,6 +35810,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -31652,6 +35820,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:map",
@@ -31660,6 +35830,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_BIG_POOL2_ENTRIES: &[LootEntry] = &[
@@ -31670,6 +35842,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -31678,6 +35852,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -31686,6 +35862,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -31694,6 +35872,8 @@ static CHESTS_UNDERWATER_RUIN_BIG_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_BIG_POOLS: &[LootPool] = &[
@@ -31730,6 +35910,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_axe",
@@ -31738,6 +35920,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_spear",
@@ -31746,6 +35930,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -31754,6 +35940,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -31762,6 +35950,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -31770,6 +35960,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_SMALL_POOL1_ENTRIES: &[LootEntry] = &[
@@ -31780,6 +35972,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_helmet",
@@ -31788,6 +35982,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -31796,6 +35992,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:map",
@@ -31804,6 +36002,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_SMALL_POOL2_ENTRIES: &[LootEntry] = &[
@@ -31814,6 +36014,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nautilus_armor",
@@ -31822,6 +36024,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_nautilus_armor",
@@ -31830,6 +36034,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_nautilus_armor",
@@ -31838,6 +36044,8 @@ static CHESTS_UNDERWATER_RUIN_SMALL_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_UNDERWATER_RUIN_SMALL_POOLS: &[LootPool] = &[
@@ -31874,6 +36082,8 @@ static CHESTS_VILLAGE_VILLAGE_ARMORER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -31882,6 +36092,8 @@ static CHESTS_VILLAGE_VILLAGE_ARMORER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -31890,6 +36102,8 @@ static CHESTS_VILLAGE_VILLAGE_ARMORER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -31898,6 +36112,8 @@ static CHESTS_VILLAGE_VILLAGE_ARMORER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_ARMORER_POOLS: &[LootPool] = &[LootPool {
@@ -31918,6 +36134,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:porkchop",
@@ -31926,6 +36144,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -31934,6 +36154,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beef",
@@ -31942,6 +36164,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:mutton",
@@ -31950,6 +36174,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -31958,6 +36184,8 @@ static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_BUTCHER_POOLS: &[LootPool] = &[LootPool {
@@ -31978,6 +36206,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:paper",
@@ -31986,6 +36216,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:compass",
@@ -31994,6 +36226,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32002,6 +36236,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -32010,6 +36246,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32019,6 +36257,8 @@ static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOL1_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_CARTOGRAPHER_POOLS: &[LootPool] = &[
     LootPool {
@@ -32047,6 +36287,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:green_dye",
@@ -32055,6 +36297,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cactus",
@@ -32063,6 +36307,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -32071,6 +36317,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32079,6 +36327,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -32087,6 +36337,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dead_bush",
@@ -32095,6 +36347,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32103,6 +36357,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32112,6 +36368,8 @@ static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_DESERT_HOUSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -32140,6 +36398,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -32148,6 +36408,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -32156,6 +36418,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:water_bucket",
@@ -32164,6 +36428,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:barrel",
@@ -32172,6 +36438,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -32180,6 +36448,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -32188,6 +36458,8 @@ static CHESTS_VILLAGE_VILLAGE_FISHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_FISHER_POOLS: &[LootPool] = &[LootPool {
@@ -32208,6 +36480,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -32216,6 +36490,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:feather",
@@ -32224,6 +36500,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:egg",
@@ -32232,6 +36510,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flint",
@@ -32240,6 +36520,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -32248,6 +36530,8 @@ static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_FLETCHER_POOLS: &[LootPool] = &[LootPool {
@@ -32268,6 +36552,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:flower_pot",
@@ -32276,6 +36562,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone",
@@ -32284,6 +36572,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_bricks",
@@ -32292,6 +36582,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32300,6 +36592,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_dye",
@@ -32308,6 +36602,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:smooth_stone",
@@ -32316,6 +36612,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32324,6 +36622,8 @@ static CHESTS_VILLAGE_VILLAGE_MASON_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_MASON_POOLS: &[LootPool] = &[LootPool {
@@ -32344,6 +36644,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dandelion",
@@ -32352,6 +36654,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:poppy",
@@ -32360,6 +36664,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -32368,6 +36674,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32376,6 +36684,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:apple",
@@ -32384,6 +36694,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -32392,6 +36704,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:feather",
@@ -32400,6 +36714,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32408,6 +36724,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_sapling",
@@ -32416,6 +36734,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32425,6 +36745,8 @@ static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootE
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_PLAINS_HOUSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -32453,6 +36775,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:short_grass",
@@ -32461,6 +36785,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tall_grass",
@@ -32469,6 +36795,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32477,6 +36805,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat_seeds",
@@ -32485,6 +36815,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32493,6 +36825,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:acacia_sapling",
@@ -32501,6 +36835,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -32509,6 +36845,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:torch",
@@ -32517,6 +36855,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bucket",
@@ -32525,6 +36865,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32534,6 +36876,8 @@ static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[Loot
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_SAVANNA_HOUSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -32562,6 +36906,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:black_wool",
@@ -32570,6 +36916,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gray_wool",
@@ -32578,6 +36926,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_wool",
@@ -32586,6 +36936,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_gray_wool",
@@ -32594,6 +36946,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32602,6 +36956,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:shears",
@@ -32610,6 +36966,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -32618,6 +36976,8 @@ static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 6i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_SHEPHERD_POOLS: &[LootPool] = &[LootPool {
@@ -32638,6 +36998,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snow_block",
@@ -32646,6 +37008,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -32654,6 +37018,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32662,6 +37028,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -32670,6 +37038,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_soup",
@@ -32678,6 +37048,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:furnace",
@@ -32686,6 +37058,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32694,6 +37068,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -32702,6 +37078,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -32710,6 +37088,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32719,6 +37099,8 @@ static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_SNOWY_HOUSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -32747,6 +37129,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fern",
@@ -32755,6 +37139,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:large_fern",
@@ -32763,6 +37149,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -32771,6 +37159,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sweet_berries",
@@ -32779,6 +37169,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32787,6 +37179,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -32795,6 +37189,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_pie",
@@ -32803,6 +37199,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32811,6 +37209,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_sapling",
@@ -32819,6 +37219,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_sign",
@@ -32827,6 +37229,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spruce_log",
@@ -32835,6 +37239,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32844,6 +37250,8 @@ static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOL1_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_TAIGA_HOUSE_POOLS: &[LootPool] = &[
     LootPool {
@@ -32872,6 +37280,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_chestplate",
@@ -32880,6 +37290,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_boots",
@@ -32888,6 +37300,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_helmet",
@@ -32896,6 +37310,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32904,6 +37320,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_leggings",
@@ -32912,6 +37330,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -32920,6 +37340,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -32928,6 +37350,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -32937,6 +37361,8 @@ static CHESTS_VILLAGE_VILLAGE_TANNERY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_TANNERY_POOLS: &[LootPool] = &[
     LootPool {
@@ -32965,6 +37391,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -32973,6 +37401,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -32981,6 +37411,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -32989,6 +37421,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -32997,6 +37431,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald",
@@ -33005,6 +37441,8 @@ static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_TEMPLE_POOLS: &[LootPool] = &[LootPool {
@@ -33025,6 +37463,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -33033,6 +37473,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -33041,6 +37483,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -33049,6 +37493,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -33057,6 +37503,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -33065,6 +37513,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -33073,6 +37523,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_shovel",
@@ -33081,6 +37533,8 @@ static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_TOOLSMITH_POOLS: &[LootPool] = &[LootPool {
@@ -33101,6 +37555,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -33109,6 +37565,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -33117,6 +37575,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -33125,6 +37585,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:apple",
@@ -33133,6 +37595,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_pickaxe",
@@ -33141,6 +37605,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -33149,6 +37615,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_spear",
@@ -33157,6 +37625,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_spear",
@@ -33165,6 +37635,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -33173,6 +37645,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -33181,6 +37655,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_leggings",
@@ -33189,6 +37665,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_boots",
@@ -33197,6 +37675,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:obsidian",
@@ -33205,6 +37685,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:oak_sapling",
@@ -33213,6 +37695,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 7i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -33221,6 +37705,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:copper_horse_armor",
@@ -33229,6 +37715,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_horse_armor",
@@ -33237,6 +37725,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_horse_armor",
@@ -33245,6 +37735,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_horse_armor",
@@ -33253,6 +37745,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -33262,6 +37756,8 @@ static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOL1_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_VILLAGE_VILLAGE_WEAPONSMITH_POOLS: &[LootPool] = &[
     LootPool {
@@ -33290,6 +37786,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_apple",
@@ -33298,6 +37796,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:enchanted_golden_apple",
@@ -33306,6 +37806,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_13",
@@ -33314,6 +37816,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_cat",
@@ -33322,6 +37826,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_chestplate",
@@ -33330,6 +37836,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_hoe",
@@ -33338,6 +37846,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -33346,6 +37856,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -33354,6 +37866,8 @@ static CHESTS_WOODLAND_MANSION_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
@@ -33364,6 +37878,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gold_ingot",
@@ -33372,6 +37888,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -33380,6 +37898,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wheat",
@@ -33388,6 +37908,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bucket",
@@ -33396,6 +37918,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:redstone",
@@ -33404,6 +37928,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:coal",
@@ -33412,6 +37938,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:melon_seeds",
@@ -33420,6 +37948,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_seeds",
@@ -33428,6 +37958,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beetroot_seeds",
@@ -33436,6 +37968,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:resin_clump",
@@ -33444,6 +37978,8 @@ static CHESTS_WOODLAND_MANSION_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_WOODLAND_MANSION_POOL2_ENTRIES: &[LootEntry] = &[
@@ -33454,6 +37990,8 @@ static CHESTS_WOODLAND_MANSION_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -33462,6 +38000,8 @@ static CHESTS_WOODLAND_MANSION_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -33470,6 +38010,8 @@ static CHESTS_WOODLAND_MANSION_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -33478,6 +38020,8 @@ static CHESTS_WOODLAND_MANSION_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static CHESTS_WOODLAND_MANSION_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -33487,6 +38031,8 @@ static CHESTS_WOODLAND_MANSION_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static CHESTS_WOODLAND_MANSION_POOLS: &[LootPool] = &[
     LootPool {
@@ -33529,6 +38075,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -33537,6 +38085,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:snowball",
@@ -33545,6 +38095,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:egg",
@@ -33553,6 +38105,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fire_charge",
@@ -33561,6 +38115,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:splash_potion",
@@ -33569,6 +38125,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:splash_potion",
@@ -33577,6 +38135,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:splash_potion",
@@ -33585,6 +38145,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -33593,6 +38155,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -33601,6 +38165,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -33609,6 +38175,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -33617,6 +38185,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 5i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static DISPENSERS_TRIAL_CHAMBERS_CHAMBER_POOLS: &[LootPool] = &[LootPool {
@@ -33636,6 +38206,8 @@ static DISPENSERS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 8i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static DISPENSERS_TRIAL_CHAMBERS_CORRIDOR_POOLS: &[LootPool] = &[LootPool {
     entries: DISPENSERS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES,
@@ -33654,6 +38226,8 @@ static DISPENSERS_TRIAL_CHAMBERS_WATER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static DISPENSERS_TRIAL_CHAMBERS_WATER_POOLS: &[LootPool] = &[LootPool {
     entries: DISPENSERS_TRIAL_CHAMBERS_WATER_POOL0_ENTRIES,
@@ -33696,6 +38270,8 @@ static ENTITIES_BLAZE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_BLAZE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_BLAZE_POOL0_ENTRIES,
@@ -33714,6 +38290,8 @@ static ENTITIES_BOGGED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_BOGGED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone",
@@ -33722,6 +38300,8 @@ static ENTITIES_BOGGED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_BOGGED_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:tipped_arrow",
@@ -33730,6 +38310,8 @@ static ENTITIES_BOGGED_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_BOGGED_POOLS: &[LootPool] = &[
     LootPool {
@@ -33764,6 +38346,8 @@ static ENTITIES_BREEZE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_BREEZE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_BREEZE_POOL0_ENTRIES,
@@ -33786,6 +38370,8 @@ static ENTITIES_CAMEL_HUSK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CAMEL_HUSK_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_CAMEL_HUSK_POOL0_ENTRIES,
@@ -33804,6 +38390,8 @@ static ENTITIES_CAT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CAT_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_CAT_POOL0_ENTRIES,
@@ -33822,6 +38410,8 @@ static ENTITIES_CAVE_SPIDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CAVE_SPIDER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:spider_eye",
@@ -33830,6 +38420,8 @@ static ENTITIES_CAVE_SPIDER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CAVE_SPIDER_POOLS: &[LootPool] = &[
     LootPool {
@@ -33857,6 +38449,8 @@ static ENTITIES_CHICKEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CHICKEN_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -33871,6 +38465,8 @@ static ENTITIES_CHICKEN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chicken",
@@ -33884,6 +38480,8 @@ static ENTITIES_CHICKEN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_CHICKEN_POOLS: &[LootPool] = &[
@@ -33918,6 +38516,8 @@ static ENTITIES_COD_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -33931,6 +38531,8 @@ static ENTITIES_COD_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_COD_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -33940,6 +38542,8 @@ static ENTITIES_COD_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_COD_POOLS: &[LootPool] = &[
     LootPool {
@@ -33967,6 +38571,8 @@ static ENTITIES_COPPER_GOLEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_COPPER_GOLEM_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_COPPER_GOLEM_POOL0_ENTRIES,
@@ -33985,6 +38591,8 @@ static ENTITIES_COW_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_COW_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -33999,6 +38607,8 @@ static ENTITIES_COW_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beef",
@@ -34012,6 +38622,8 @@ static ENTITIES_COW_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_COW_POOLS: &[LootPool] = &[
@@ -34044,6 +38656,8 @@ static ENTITIES_CREEPER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34053,6 +38667,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_cat",
@@ -34061,6 +38677,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_blocks",
@@ -34069,6 +38687,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_chirp",
@@ -34077,6 +38697,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_far",
@@ -34085,6 +38707,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_mall",
@@ -34093,6 +38717,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_mellohi",
@@ -34101,6 +38727,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_stal",
@@ -34109,6 +38737,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_strad",
@@ -34117,6 +38747,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_ward",
@@ -34125,6 +38757,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_11",
@@ -34133,6 +38767,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_wait",
@@ -34141,6 +38777,8 @@ static ENTITIES_CREEPER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_CREEPER_POOLS: &[LootPool] = &[
@@ -34184,6 +38822,8 @@ static ENTITIES_DOLPHIN_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -34197,6 +38837,8 @@ static ENTITIES_DOLPHIN_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_DOLPHIN_POOLS: &[LootPool] = &[LootPool {
@@ -34216,6 +38858,8 @@ static ENTITIES_DONKEY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_DONKEY_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_DONKEY_POOL0_ENTRIES,
@@ -34234,6 +38878,8 @@ static ENTITIES_DROWNED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_DROWNED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:copper_ingot",
@@ -34242,6 +38888,8 @@ static ENTITIES_DROWNED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_DROWNED_POOLS: &[LootPool] = &[
     LootPool {
@@ -34276,6 +38924,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ELDER_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34290,6 +38940,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -34303,6 +38955,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:prismarine_crystals",
@@ -34311,6 +38965,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_ELDER_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -34320,6 +38976,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ELDER_GUARDIAN_POOL3_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34329,6 +38987,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -34337,6 +38997,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tropical_fish",
@@ -34345,6 +39007,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pufferfish",
@@ -34353,6 +39017,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL3_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_ELDER_GUARDIAN_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -34362,6 +39028,8 @@ static ENTITIES_ELDER_GUARDIAN_POOL4_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ELDER_GUARDIAN_POOLS: &[LootPool] = &[
     LootPool {
@@ -34421,6 +39089,8 @@ static ENTITIES_ENDERMAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ENDERMAN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_ENDERMAN_POOL0_ENTRIES,
@@ -34443,6 +39113,8 @@ static ENTITIES_EVOKER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_EVOKER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:emerald",
@@ -34451,6 +39123,8 @@ static ENTITIES_EVOKER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_EVOKER_POOLS: &[LootPool] = &[
     LootPool {
@@ -34486,6 +39160,8 @@ static ENTITIES_GHAST_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_GHAST_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:gunpowder",
@@ -34494,6 +39170,8 @@ static ENTITIES_GHAST_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_GHAST_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:music_disc_tears",
@@ -34502,6 +39180,8 @@ static ENTITIES_GHAST_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_GHAST_POOLS: &[LootPool] = &[
     LootPool {
@@ -34540,6 +39220,8 @@ static ENTITIES_GLOW_SQUID_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_GLOW_SQUID_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_GLOW_SQUID_POOL0_ENTRIES,
@@ -34562,6 +39244,8 @@ static ENTITIES_GUARDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34576,6 +39260,8 @@ static ENTITIES_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -34589,6 +39275,8 @@ static ENTITIES_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:prismarine_crystals",
@@ -34597,6 +39285,8 @@ static ENTITIES_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[
@@ -34607,6 +39297,8 @@ static ENTITIES_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -34615,6 +39307,8 @@ static ENTITIES_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tropical_fish",
@@ -34623,6 +39317,8 @@ static ENTITIES_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pufferfish",
@@ -34631,6 +39327,8 @@ static ENTITIES_GUARDIAN_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_GUARDIAN_POOLS: &[LootPool] = &[
@@ -34683,6 +39381,8 @@ static ENTITIES_HOGLIN_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:porkchop",
@@ -34696,6 +39396,8 @@ static ENTITIES_HOGLIN_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_HOGLIN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -34705,6 +39407,8 @@ static ENTITIES_HOGLIN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_HOGLIN_POOLS: &[LootPool] = &[
     LootPool {
@@ -34732,6 +39436,8 @@ static ENTITIES_HORSE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_HORSE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_HORSE_POOL0_ENTRIES,
@@ -34750,6 +39456,8 @@ static ENTITIES_HUSK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_HUSK_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:rabbit_foot",
@@ -34758,6 +39466,8 @@ static ENTITIES_HUSK_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34767,6 +39477,8 @@ static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:carrot",
@@ -34775,6 +39487,8 @@ static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -34788,6 +39502,8 @@ static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -34801,6 +39517,8 @@ static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_HUSK_POOLS: &[LootPool] = &[
@@ -34847,6 +39565,8 @@ static ENTITIES_IRON_GOLEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_IRON_GOLEM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:iron_ingot",
@@ -34855,6 +39575,8 @@ static ENTITIES_IRON_GOLEM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 5i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_IRON_GOLEM_POOLS: &[LootPool] = &[
     LootPool {
@@ -34882,6 +39604,8 @@ static ENTITIES_LLAMA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_LLAMA_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_LLAMA_POOL0_ENTRIES,
@@ -34901,6 +39625,8 @@ static ENTITIES_MAGMA_CUBE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pearlescent_froglight",
@@ -34909,6 +39635,8 @@ static ENTITIES_MAGMA_CUBE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:verdant_froglight",
@@ -34917,6 +39645,8 @@ static ENTITIES_MAGMA_CUBE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ochre_froglight",
@@ -34925,6 +39655,8 @@ static ENTITIES_MAGMA_CUBE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_MAGMA_CUBE_POOLS: &[LootPool] = &[LootPool {
@@ -34948,6 +39680,8 @@ static ENTITIES_MOOSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_MOOSHROOM_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -34962,6 +39696,8 @@ static ENTITIES_MOOSHROOM_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:beef",
@@ -34975,6 +39711,8 @@ static ENTITIES_MOOSHROOM_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_MOOSHROOM_POOLS: &[LootPool] = &[
@@ -35003,6 +39741,8 @@ static ENTITIES_MULE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_MULE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_MULE_POOL0_ENTRIES,
@@ -35021,6 +39761,8 @@ static ENTITIES_NAUTILUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_NAUTILUS_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_NAUTILUS_POOL0_ENTRIES,
@@ -35050,6 +39792,8 @@ static ENTITIES_PANDA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PANDA_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_PANDA_POOL0_ENTRIES,
@@ -35068,6 +39812,8 @@ static ENTITIES_PARCHED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PARCHED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone",
@@ -35076,6 +39822,8 @@ static ENTITIES_PARCHED_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PARCHED_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:tipped_arrow",
@@ -35084,6 +39832,8 @@ static ENTITIES_PARCHED_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PARCHED_POOLS: &[LootPool] = &[
     LootPool {
@@ -35118,6 +39868,8 @@ static ENTITIES_PARROT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PARROT_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_PARROT_POOL0_ENTRIES,
@@ -35136,6 +39888,8 @@ static ENTITIES_PHANTOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PHANTOM_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_PHANTOM_POOL0_ENTRIES,
@@ -35160,6 +39914,8 @@ static ENTITIES_PIG_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:porkchop",
@@ -35173,6 +39929,8 @@ static ENTITIES_PIG_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_PIG_POOLS: &[LootPool] = &[LootPool {
@@ -35200,6 +39958,8 @@ static ENTITIES_PILLAGER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PILLAGER_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_PILLAGER_POOL0_ENTRIES,
@@ -35228,6 +39988,8 @@ static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -35241,6 +40003,8 @@ static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_salmon",
@@ -35254,6 +40018,8 @@ static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -35267,6 +40033,8 @@ static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_POLAR_BEAR_POOLS: &[LootPool] = &[LootPool {
@@ -35286,6 +40054,8 @@ static ENTITIES_PUFFERFISH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PUFFERFISH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone_meal",
@@ -35294,6 +40064,8 @@ static ENTITIES_PUFFERFISH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_PUFFERFISH_POOLS: &[LootPool] = &[
     LootPool {
@@ -35321,6 +40093,8 @@ static ENTITIES_RABBIT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_RABBIT_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -35335,6 +40109,8 @@ static ENTITIES_RABBIT_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rabbit",
@@ -35348,6 +40124,8 @@ static ENTITIES_RABBIT_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_RABBIT_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -35357,6 +40135,8 @@ static ENTITIES_RABBIT_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_RABBIT_POOLS: &[LootPool] = &[
     LootPool {
@@ -35398,6 +40178,8 @@ static ENTITIES_RAVAGER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_RAVAGER_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_RAVAGER_POOL0_ENTRIES,
@@ -35422,6 +40204,8 @@ static ENTITIES_SALMON_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -35435,6 +40219,8 @@ static ENTITIES_SALMON_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_SALMON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -35444,6 +40230,8 @@ static ENTITIES_SALMON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SALMON_POOLS: &[LootPool] = &[
     LootPool {
@@ -35477,6 +40265,8 @@ static ENTITIES_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:mutton",
@@ -35490,6 +40280,8 @@ static ENTITIES_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
@@ -35500,6 +40292,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:orange_wool",
@@ -35508,6 +40302,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magenta_wool",
@@ -35516,6 +40312,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_blue_wool",
@@ -35524,6 +40322,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_wool",
@@ -35532,6 +40332,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lime_wool",
@@ -35540,6 +40342,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pink_wool",
@@ -35548,6 +40352,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gray_wool",
@@ -35556,6 +40362,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_gray_wool",
@@ -35564,6 +40372,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cyan_wool",
@@ -35572,6 +40382,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:purple_wool",
@@ -35580,6 +40392,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_wool",
@@ -35588,6 +40402,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_wool",
@@ -35596,6 +40412,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:green_wool",
@@ -35604,6 +40422,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_wool",
@@ -35612,6 +40432,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:black_wool",
@@ -35620,6 +40442,8 @@ static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_SHEEP_POOLS: &[LootPool] = &[
@@ -35648,6 +40472,8 @@ static ENTITIES_SHEEP_BLACK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_BLACK_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_BLACK_POOL0_ENTRIES,
@@ -35666,6 +40492,8 @@ static ENTITIES_SHEEP_BLUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_BLUE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_BLUE_POOL0_ENTRIES,
@@ -35684,6 +40512,8 @@ static ENTITIES_SHEEP_BROWN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_BROWN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_BROWN_POOL0_ENTRIES,
@@ -35702,6 +40532,8 @@ static ENTITIES_SHEEP_CYAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_CYAN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_CYAN_POOL0_ENTRIES,
@@ -35720,6 +40552,8 @@ static ENTITIES_SHEEP_GRAY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_GRAY_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_GRAY_POOL0_ENTRIES,
@@ -35738,6 +40572,8 @@ static ENTITIES_SHEEP_GREEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_GREEN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_GREEN_POOL0_ENTRIES,
@@ -35756,6 +40592,8 @@ static ENTITIES_SHEEP_LIGHT_BLUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_LIGHT_BLUE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_LIGHT_BLUE_POOL0_ENTRIES,
@@ -35774,6 +40612,8 @@ static ENTITIES_SHEEP_LIGHT_GRAY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_LIGHT_GRAY_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_LIGHT_GRAY_POOL0_ENTRIES,
@@ -35792,6 +40632,8 @@ static ENTITIES_SHEEP_LIME_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_LIME_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_LIME_POOL0_ENTRIES,
@@ -35810,6 +40652,8 @@ static ENTITIES_SHEEP_MAGENTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_MAGENTA_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_MAGENTA_POOL0_ENTRIES,
@@ -35828,6 +40672,8 @@ static ENTITIES_SHEEP_ORANGE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_ORANGE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_ORANGE_POOL0_ENTRIES,
@@ -35846,6 +40692,8 @@ static ENTITIES_SHEEP_PINK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_PINK_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_PINK_POOL0_ENTRIES,
@@ -35864,6 +40712,8 @@ static ENTITIES_SHEEP_PURPLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_PURPLE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_PURPLE_POOL0_ENTRIES,
@@ -35882,6 +40732,8 @@ static ENTITIES_SHEEP_RED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_RED_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_RED_POOL0_ENTRIES,
@@ -35900,6 +40752,8 @@ static ENTITIES_SHEEP_WHITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_WHITE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_WHITE_POOL0_ENTRIES,
@@ -35918,6 +40772,8 @@ static ENTITIES_SHEEP_YELLOW_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHEEP_YELLOW_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHEEP_YELLOW_POOL0_ENTRIES,
@@ -35936,6 +40792,8 @@ static ENTITIES_SHULKER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SHULKER_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SHULKER_POOL0_ENTRIES,
@@ -35962,6 +40820,8 @@ static ENTITIES_SKELETON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SKELETON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone",
@@ -35970,6 +40830,8 @@ static ENTITIES_SKELETON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SKELETON_POOLS: &[LootPool] = &[
     LootPool {
@@ -35997,6 +40859,8 @@ static ENTITIES_SKELETON_HORSE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SKELETON_HORSE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SKELETON_HORSE_POOL0_ENTRIES,
@@ -36016,6 +40880,8 @@ static ENTITIES_SLIME_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:slime_ball",
@@ -36024,6 +40890,8 @@ static ENTITIES_SLIME_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_SLIME_POOLS: &[LootPool] = &[LootPool {
@@ -36047,6 +40915,8 @@ static ENTITIES_SNOW_GOLEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 15i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SNOW_GOLEM_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SNOW_GOLEM_POOL0_ENTRIES,
@@ -36065,6 +40935,8 @@ static ENTITIES_SPIDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SPIDER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:spider_eye",
@@ -36073,6 +40945,8 @@ static ENTITIES_SPIDER_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SPIDER_POOLS: &[LootPool] = &[
     LootPool {
@@ -36100,6 +40974,8 @@ static ENTITIES_SQUID_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_SQUID_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_SQUID_POOL0_ENTRIES,
@@ -36118,6 +40994,8 @@ static ENTITIES_STRAY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_STRAY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone",
@@ -36126,6 +41004,8 @@ static ENTITIES_STRAY_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_STRAY_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:tipped_arrow",
@@ -36134,6 +41014,8 @@ static ENTITIES_STRAY_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_STRAY_POOLS: &[LootPool] = &[
     LootPool {
@@ -36168,6 +41050,8 @@ static ENTITIES_STRIDER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 5i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_STRIDER_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_STRIDER_POOL0_ENTRIES,
@@ -36194,6 +41078,8 @@ static ENTITIES_TRADER_LLAMA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_TRADER_LLAMA_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_TRADER_LLAMA_POOL0_ENTRIES,
@@ -36212,6 +41098,8 @@ static ENTITIES_TROPICAL_FISH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_TROPICAL_FISH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone_meal",
@@ -36220,6 +41108,8 @@ static ENTITIES_TROPICAL_FISH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_TROPICAL_FISH_POOLS: &[LootPool] = &[
     LootPool {
@@ -36247,6 +41137,8 @@ static ENTITIES_TURTLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_TURTLE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bowl",
@@ -36255,6 +41147,8 @@ static ENTITIES_TURTLE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_TURTLE_POOLS: &[LootPool] = &[
     LootPool {
@@ -36290,6 +41184,8 @@ static ENTITIES_VINDICATOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_VINDICATOR_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_VINDICATOR_POOL0_ENTRIES,
@@ -36312,6 +41208,8 @@ static ENTITIES_WARDEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_WARDEN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_WARDEN_POOL0_ENTRIES,
@@ -36331,6 +41229,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:sugar",
@@ -36339,6 +41239,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spider_eye",
@@ -36347,6 +41249,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:glass_bottle",
@@ -36355,6 +41259,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gunpowder",
@@ -36363,6 +41269,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -36371,6 +41279,8 @@ static ENTITIES_WITCH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_WITCH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -36380,6 +41290,8 @@ static ENTITIES_WITCH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 8i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_WITCH_POOLS: &[LootPool] = &[
     LootPool {
@@ -36411,6 +41323,8 @@ static ENTITIES_WITHER_SKELETON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_WITHER_SKELETON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone",
@@ -36419,6 +41333,8 @@ static ENTITIES_WITHER_SKELETON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_WITHER_SKELETON_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:wither_skeleton_skull",
@@ -36427,6 +41343,8 @@ static ENTITIES_WITHER_SKELETON_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_WITHER_SKELETON_POOLS: &[LootPool] = &[
     LootPool {
@@ -36472,6 +41390,8 @@ static ENTITIES_ZOGLIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOGLIN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_ZOGLIN_POOL0_ENTRIES,
@@ -36490,6 +41410,8 @@ static ENTITIES_ZOMBIE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:red_mushroom",
@@ -36498,6 +41420,8 @@ static ENTITIES_ZOMBIE_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -36507,6 +41431,8 @@ static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:carrot",
@@ -36515,6 +41441,8 @@ static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -36528,6 +41456,8 @@ static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -36541,6 +41471,8 @@ static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_ZOMBIE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -36550,6 +41482,8 @@ static ENTITIES_ZOMBIE_POOL3_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_POOLS: &[LootPool] = &[
     LootPool {
@@ -36598,6 +41532,8 @@ static ENTITIES_ZOMBIE_HORSE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_HORSE_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_ZOMBIE_HORSE_POOL0_ENTRIES,
@@ -36616,6 +41552,8 @@ static ENTITIES_ZOMBIE_NAUTILUS_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_NAUTILUS_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_ZOMBIE_NAUTILUS_POOL0_ENTRIES,
@@ -36634,6 +41572,8 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
@@ -36643,6 +41583,8 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:carrot",
@@ -36651,6 +41593,8 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -36664,6 +41608,8 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ]),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potato",
@@ -36677,6 +41623,8 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
             },
         ])),
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static ENTITIES_ZOMBIE_VILLAGER_POOLS: &[LootPool] = &[
@@ -36712,6 +41660,8 @@ static ENTITIES_ZOMBIFIED_PIGLIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIFIED_PIGLIN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:gold_nugget",
@@ -36720,6 +41670,8 @@ static ENTITIES_ZOMBIFIED_PIGLIN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIFIED_PIGLIN_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:gold_ingot",
@@ -36728,6 +41680,8 @@ static ENTITIES_ZOMBIFIED_PIGLIN_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static ENTITIES_ZOMBIFIED_PIGLIN_POOLS: &[LootPool] = &[
     LootPool {
@@ -36770,6 +41724,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_chestplate",
@@ -36778,6 +41734,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -36786,6 +41744,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -36794,6 +41754,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -36802,6 +41764,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -36810,6 +41774,8 @@ static EQUIPMENT_TRIAL_CHAMBER_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static EQUIPMENT_TRIAL_CHAMBER_POOLS: &[LootPool] = &[LootPool {
@@ -36830,6 +41796,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_chestplate",
@@ -36838,6 +41806,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -36846,6 +41816,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -36854,6 +41826,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -36862,6 +41836,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -36870,6 +41846,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL1_ENTRIES: &[LootEntry] = &[
@@ -36880,6 +41858,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -36888,6 +41868,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_sword",
@@ -36896,6 +41878,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_sword",
@@ -36904,6 +41888,8 @@ static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static EQUIPMENT_TRIAL_CHAMBER_MELEE_POOLS: &[LootPool] = &[
@@ -36933,6 +41919,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_chestplate",
@@ -36941,6 +41929,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_helmet",
@@ -36949,6 +41939,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_chestplate",
@@ -36957,6 +41949,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_helmet",
@@ -36965,6 +41959,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_chestplate",
@@ -36973,6 +41969,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::RandomChance { chance: 0.5f32 },
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL1_ENTRIES: &[LootEntry] = &[
@@ -36983,6 +41981,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -36991,6 +41991,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -36999,6 +42001,8 @@ static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOL1_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static EQUIPMENT_TRIAL_CHAMBER_RANGED_POOLS: &[LootPool] = &[
@@ -37027,6 +42031,8 @@ static GAMEPLAY_ARMADILLO_SHED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_ARMADILLO_SHED_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_ARMADILLO_SHED_POOL0_ENTRIES,
@@ -37046,6 +42052,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rabbit_foot",
@@ -37054,6 +42062,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chicken",
@@ -37062,6 +42072,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:feather",
@@ -37070,6 +42082,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -37078,6 +42092,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -37086,6 +42102,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:phantom_membrane",
@@ -37094,6 +42112,8 @@ static GAMEPLAY_CAT_MORNING_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_CAT_MORNING_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37114,6 +42134,8 @@ static GAMEPLAY_CHICKEN_LAY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_egg",
@@ -37122,6 +42144,8 @@ static GAMEPLAY_CHICKEN_LAY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_egg",
@@ -37130,6 +42154,8 @@ static GAMEPLAY_CHICKEN_LAY_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_CHICKEN_LAY_POOLS: &[LootPool] = &[LootPool {
@@ -37150,6 +42176,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_boots",
@@ -37158,6 +42186,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -37166,6 +42196,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone",
@@ -37174,6 +42206,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -37182,6 +42216,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -37190,6 +42226,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -37198,6 +42236,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bowl",
@@ -37206,6 +42246,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -37214,6 +42256,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ink_sac",
@@ -37222,6 +42266,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tripwire_hook",
@@ -37230,6 +42276,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -37238,6 +42286,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo",
@@ -37246,6 +42296,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:name_tag",
@@ -37254,6 +42306,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -37262,6 +42316,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -37270,6 +42326,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -37278,6 +42336,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -37286,6 +42346,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:nautilus_shell",
@@ -37294,6 +42356,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cod",
@@ -37302,6 +42366,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -37310,6 +42376,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tropical_fish",
@@ -37318,6 +42386,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pufferfish",
@@ -37326,6 +42396,8 @@ static GAMEPLAY_FISHING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_FISHING_POOLS: &[LootPool] = &[LootPool {
@@ -37346,6 +42418,8 @@ static GAMEPLAY_FISHING_FISH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -37354,6 +42428,8 @@ static GAMEPLAY_FISHING_FISH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tropical_fish",
@@ -37362,6 +42438,8 @@ static GAMEPLAY_FISHING_FISH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pufferfish",
@@ -37370,6 +42448,8 @@ static GAMEPLAY_FISHING_FISH_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_FISHING_FISH_POOLS: &[LootPool] = &[LootPool {
@@ -37390,6 +42470,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather_boots",
@@ -37398,6 +42480,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -37406,6 +42490,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bone",
@@ -37414,6 +42500,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -37422,6 +42510,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -37430,6 +42520,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -37438,6 +42530,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bowl",
@@ -37446,6 +42540,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stick",
@@ -37454,6 +42550,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ink_sac",
@@ -37462,6 +42560,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 10i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tripwire_hook",
@@ -37470,6 +42570,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:rotten_flesh",
@@ -37478,6 +42580,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bamboo",
@@ -37486,6 +42590,8 @@ static GAMEPLAY_FISHING_JUNK_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_FISHING_JUNK_POOLS: &[LootPool] = &[LootPool {
@@ -37506,6 +42612,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:saddle",
@@ -37514,6 +42622,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bow",
@@ -37522,6 +42632,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fishing_rod",
@@ -37530,6 +42642,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:book",
@@ -37538,6 +42652,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:nautilus_shell",
@@ -37546,6 +42662,8 @@ static GAMEPLAY_FISHING_TREASURE_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_FISHING_TREASURE_POOLS: &[LootPool] = &[LootPool {
@@ -37566,6 +42684,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_ARMORER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_chestplate",
@@ -37574,6 +42694,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_ARMORER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_leggings",
@@ -37582,6 +42704,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_ARMORER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:chainmail_boots",
@@ -37590,6 +42714,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_ARMORER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_ARMORER_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37609,6 +42735,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BABY_GIFT_POOL0_ENTRIES: &[LootEntry] = &[Lo
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_BABY_GIFT_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_HERO_OF_THE_VILLAGE_BABY_GIFT_POOL0_ENTRIES,
@@ -37628,6 +42756,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_chicken",
@@ -37636,6 +42766,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_porkchop",
@@ -37644,6 +42776,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_beef",
@@ -37652,6 +42786,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cooked_mutton",
@@ -37660,6 +42796,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = &
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_BUTCHER_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37680,6 +42818,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_CARTOGRAPHER_GIFT_POOL0_ENTRIES: &[LootEntry
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:paper",
@@ -37688,6 +42828,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_CARTOGRAPHER_GIFT_POOL0_ENTRIES: &[LootEntry
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_CARTOGRAPHER_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37708,6 +42850,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_CLERIC_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lapis_lazuli",
@@ -37716,6 +42860,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_CLERIC_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_CLERIC_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37736,6 +42882,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FARMER_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pumpkin_pie",
@@ -37744,6 +42892,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FARMER_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cookie",
@@ -37752,6 +42902,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FARMER_GIFT_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_FARMER_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37772,6 +42924,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FISHERMAN_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:salmon",
@@ -37780,6 +42934,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FISHERMAN_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_FISHERMAN_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37800,6 +42956,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37808,6 +42966,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37816,6 +42976,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37824,6 +42986,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37832,6 +42996,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37840,6 +43006,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37848,6 +43016,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37856,6 +43026,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37864,6 +43036,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37872,6 +43046,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37880,6 +43056,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37888,6 +43066,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37896,6 +43076,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:tipped_arrow",
@@ -37904,6 +43086,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_FLETCHER_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -37923,6 +43107,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_LEATHERWORKER_GIFT_POOL0_ENTRIES: &[LootEntr
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_LEATHERWORKER_GIFT_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_HERO_OF_THE_VILLAGE_LEATHERWORKER_GIFT_POOL0_ENTRIES,
@@ -37941,6 +43127,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_LIBRARIAN_GIFT_POOL0_ENTRIES: &[LootEntry] =
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_LIBRARIAN_GIFT_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_HERO_OF_THE_VILLAGE_LIBRARIAN_GIFT_POOL0_ENTRIES,
@@ -37959,6 +43147,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_MASON_GIFT_POOL0_ENTRIES: &[LootEntry] = &[L
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_MASON_GIFT_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_HERO_OF_THE_VILLAGE_MASON_GIFT_POOL0_ENTRIES,
@@ -37978,6 +43168,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:orange_wool",
@@ -37986,6 +43178,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magenta_wool",
@@ -37994,6 +43188,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_blue_wool",
@@ -38002,6 +43198,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_wool",
@@ -38010,6 +43208,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lime_wool",
@@ -38018,6 +43218,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pink_wool",
@@ -38026,6 +43228,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gray_wool",
@@ -38034,6 +43238,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_gray_wool",
@@ -38042,6 +43248,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cyan_wool",
@@ -38050,6 +43258,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:purple_wool",
@@ -38058,6 +43268,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_wool",
@@ -38066,6 +43278,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_wool",
@@ -38074,6 +43288,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:green_wool",
@@ -38082,6 +43298,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_wool",
@@ -38090,6 +43308,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:black_wool",
@@ -38098,6 +43318,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_SHEPHERD_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -38118,6 +43340,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_TOOLSMITH_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_axe",
@@ -38126,6 +43350,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_TOOLSMITH_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_hoe",
@@ -38134,6 +43360,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_TOOLSMITH_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:stone_shovel",
@@ -38142,6 +43370,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_TOOLSMITH_GIFT_POOL0_ENTRIES: &[LootEntry] =
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_TOOLSMITH_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -38161,6 +43391,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_UNEMPLOYED_GIFT_POOL0_ENTRIES: &[LootEntry] 
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_UNEMPLOYED_GIFT_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_HERO_OF_THE_VILLAGE_UNEMPLOYED_GIFT_POOL0_ENTRIES,
@@ -38180,6 +43412,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_WEAPONSMITH_GIFT_POOL0_ENTRIES: &[LootEntry]
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_axe",
@@ -38188,6 +43422,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_WEAPONSMITH_GIFT_POOL0_ENTRIES: &[LootEntry]
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_axe",
@@ -38196,6 +43432,8 @@ static GAMEPLAY_HERO_OF_THE_VILLAGE_WEAPONSMITH_GIFT_POOL0_ENTRIES: &[LootEntry]
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_HERO_OF_THE_VILLAGE_WEAPONSMITH_GIFT_POOLS: &[LootPool] = &[LootPool {
@@ -38215,6 +43453,8 @@ static GAMEPLAY_PANDA_SNEEZE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_PANDA_SNEEZE_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_PANDA_SNEEZE_POOL0_ENTRIES,
@@ -38234,6 +43474,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_boots",
@@ -38242,6 +43484,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -38250,6 +43494,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:splash_potion",
@@ -38258,6 +43504,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -38266,6 +43514,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_nugget",
@@ -38274,6 +43524,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 36i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:ender_pearl",
@@ -38282,6 +43534,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:dried_ghast",
@@ -38290,6 +43544,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:string",
@@ -38298,6 +43554,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 9i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:quartz",
@@ -38306,6 +43564,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:obsidian",
@@ -38314,6 +43574,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:crying_obsidian",
@@ -38322,6 +43584,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fire_charge",
@@ -38330,6 +43594,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:leather",
@@ -38338,6 +43604,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:soul_sand",
@@ -38346,6 +43614,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:nether_brick",
@@ -38354,6 +43624,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:spectral_arrow",
@@ -38362,6 +43634,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 12i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gravel",
@@ -38370,6 +43644,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 16i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blackstone",
@@ -38378,6 +43654,8 @@ static GAMEPLAY_PIGLIN_BARTERING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 16i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_PIGLIN_BARTERING_POOLS: &[LootPool] = &[LootPool {
@@ -38398,6 +43676,8 @@ static GAMEPLAY_SNIFFER_DIGGING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pitcher_pod",
@@ -38406,6 +43686,8 @@ static GAMEPLAY_SNIFFER_DIGGING_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static GAMEPLAY_SNIFFER_DIGGING_POOLS: &[LootPool] = &[LootPool {
@@ -38425,6 +43707,8 @@ static GAMEPLAY_TURTLE_GROW_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static GAMEPLAY_TURTLE_GROW_POOLS: &[LootPool] = &[LootPool {
     entries: GAMEPLAY_TURTLE_GROW_POOL0_ENTRIES,
@@ -38443,6 +43727,8 @@ static HARVEST_BEEHIVE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 3i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static HARVEST_BEEHIVE_POOLS: &[LootPool] = &[LootPool {
     entries: HARVEST_BEEHIVE_POOL0_ENTRIES,
@@ -38461,6 +43747,8 @@ static HARVEST_CAVE_VINE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static HARVEST_CAVE_VINE_POOLS: &[LootPool] = &[LootPool {
     entries: HARVEST_CAVE_VINE_POOL0_ENTRIES,
@@ -38481,6 +43769,8 @@ static HARVEST_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
         properties: &[("age", "3")],
     },
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static HARVEST_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
@@ -38489,6 +43779,8 @@ static HARVEST_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 2i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static HARVEST_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -38517,6 +43809,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -38525,6 +43819,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 8i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:iron_ingot",
@@ -38533,6 +43829,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:trial_key",
@@ -38541,6 +43839,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:music_disc_creator_music_box",
@@ -38549,6 +43849,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond",
@@ -38557,6 +43859,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:emerald_block",
@@ -38565,6 +43869,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:diamond_block",
@@ -38573,6 +43879,8 @@ static POTS_TRIAL_CHAMBERS_CORRIDOR_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static POTS_TRIAL_CHAMBERS_CORRIDOR_POOLS: &[LootPool] = &[LootPool {
@@ -38593,6 +43901,8 @@ static SHEARING_BOGGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_mushroom",
@@ -38601,6 +43911,8 @@ static SHEARING_BOGGED_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SHEARING_BOGGED_POOLS: &[LootPool] = &[LootPool {
@@ -38621,6 +43933,8 @@ static SHEARING_MOOSHROOM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_mushroom",
@@ -38629,6 +43943,8 @@ static SHEARING_MOOSHROOM_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SHEARING_MOOSHROOM_POOLS: &[LootPool] = &[LootPool {
@@ -38648,6 +43964,8 @@ static SHEARING_MOOSHROOM_BROWN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_MOOSHROOM_BROWN_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_MOOSHROOM_BROWN_POOL0_ENTRIES,
@@ -38666,6 +43984,8 @@ static SHEARING_MOOSHROOM_RED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_MOOSHROOM_RED_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_MOOSHROOM_RED_POOL0_ENTRIES,
@@ -38685,6 +44005,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:orange_wool",
@@ -38693,6 +44015,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:magenta_wool",
@@ -38701,6 +44025,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_blue_wool",
@@ -38709,6 +44035,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:yellow_wool",
@@ -38717,6 +44045,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lime_wool",
@@ -38725,6 +44055,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:pink_wool",
@@ -38733,6 +44065,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:gray_wool",
@@ -38741,6 +44075,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:light_gray_wool",
@@ -38749,6 +44085,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:cyan_wool",
@@ -38757,6 +44095,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:purple_wool",
@@ -38765,6 +44105,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:blue_wool",
@@ -38773,6 +44115,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:brown_wool",
@@ -38781,6 +44125,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:green_wool",
@@ -38789,6 +44135,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:red_wool",
@@ -38797,6 +44145,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:black_wool",
@@ -38805,6 +44155,8 @@ static SHEARING_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SHEARING_SHEEP_POOLS: &[LootPool] = &[LootPool {
@@ -38824,6 +44176,8 @@ static SHEARING_SHEEP_BLACK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_BLACK_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_BLACK_POOL0_ENTRIES,
@@ -38842,6 +44196,8 @@ static SHEARING_SHEEP_BLUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_BLUE_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_BLUE_POOL0_ENTRIES,
@@ -38860,6 +44216,8 @@ static SHEARING_SHEEP_BROWN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_BROWN_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_BROWN_POOL0_ENTRIES,
@@ -38878,6 +44236,8 @@ static SHEARING_SHEEP_CYAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_CYAN_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_CYAN_POOL0_ENTRIES,
@@ -38896,6 +44256,8 @@ static SHEARING_SHEEP_GRAY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_GRAY_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_GRAY_POOL0_ENTRIES,
@@ -38914,6 +44276,8 @@ static SHEARING_SHEEP_GREEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_GREEN_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_GREEN_POOL0_ENTRIES,
@@ -38932,6 +44296,8 @@ static SHEARING_SHEEP_LIGHT_BLUE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_LIGHT_BLUE_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_LIGHT_BLUE_POOL0_ENTRIES,
@@ -38950,6 +44316,8 @@ static SHEARING_SHEEP_LIGHT_GRAY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_LIGHT_GRAY_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_LIGHT_GRAY_POOL0_ENTRIES,
@@ -38968,6 +44336,8 @@ static SHEARING_SHEEP_LIME_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_LIME_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_LIME_POOL0_ENTRIES,
@@ -38986,6 +44356,8 @@ static SHEARING_SHEEP_MAGENTA_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_MAGENTA_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_MAGENTA_POOL0_ENTRIES,
@@ -39004,6 +44376,8 @@ static SHEARING_SHEEP_ORANGE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_ORANGE_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_ORANGE_POOL0_ENTRIES,
@@ -39022,6 +44396,8 @@ static SHEARING_SHEEP_PINK_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_PINK_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_PINK_POOL0_ENTRIES,
@@ -39040,6 +44416,8 @@ static SHEARING_SHEEP_PURPLE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_PURPLE_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_PURPLE_POOL0_ENTRIES,
@@ -39058,6 +44436,8 @@ static SHEARING_SHEEP_RED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_RED_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_RED_POOL0_ENTRIES,
@@ -39076,6 +44456,8 @@ static SHEARING_SHEEP_WHITE_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_WHITE_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_WHITE_POOL0_ENTRIES,
@@ -39094,6 +44476,8 @@ static SHEARING_SHEEP_YELLOW_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SHEEP_YELLOW_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SHEEP_YELLOW_POOL0_ENTRIES,
@@ -39112,6 +44496,8 @@ static SHEARING_SNOW_GOLEM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SHEARING_SNOW_GOLEM_POOLS: &[LootPool] = &[LootPool {
     entries: SHEARING_SNOW_GOLEM_POOL0_ENTRIES,
@@ -39131,6 +44517,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -39139,6 +44527,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 4i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:golden_carrot",
@@ -39147,6 +44537,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 2i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -39155,6 +44547,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -39163,6 +44557,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = 
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SPAWNERS_OMINOUS_TRIAL_CHAMBER_CONSUMABLES_POOLS: &[LootPool] = &[LootPool {
@@ -39182,6 +44578,8 @@ static SPAWNERS_OMINOUS_TRIAL_CHAMBER_KEY_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SPAWNERS_OMINOUS_TRIAL_CHAMBER_KEY_POOLS: &[LootPool] = &[LootPool {
     entries: SPAWNERS_OMINOUS_TRIAL_CHAMBER_KEY_POOL0_ENTRIES,
@@ -39201,6 +44599,8 @@ static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:bread",
@@ -39209,6 +44609,8 @@ static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:baked_potato",
@@ -39217,6 +44619,8 @@ static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -39225,6 +44629,8 @@ static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:potion",
@@ -39233,6 +44639,8 @@ static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOL0_ENTRIES: &[LootEntry] = &[
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SPAWNERS_TRIAL_CHAMBER_CONSUMABLES_POOLS: &[LootPool] = &[LootPool {
@@ -39253,6 +44661,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39261,6 +44671,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39269,6 +44681,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39277,6 +44691,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39285,6 +44701,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39293,6 +44711,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:lingering_potion",
@@ -39301,6 +44721,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL0_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEntry] = &[
@@ -39311,6 +44733,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -39319,6 +44743,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:arrow",
@@ -39327,6 +44753,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEn
         max_count: 1i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:fire_charge",
@@ -39335,6 +44763,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEn
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
     LootEntry {
         item: "minecraft:wind_charge",
@@ -39343,6 +44773,8 @@ static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOL1_ENTRIES: &[LootEn
         max_count: 3i32,
         condition: LootCondition::None,
         bonus_formula: None,
+        limit: None,
+        explosion_decay: false,
     },
 ];
 static SPAWNERS_TRIAL_CHAMBER_ITEMS_TO_DROP_WHEN_OMINOUS_POOLS: &[LootPool] = &[
@@ -39371,6 +44803,8 @@ static SPAWNERS_TRIAL_CHAMBER_KEY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static SPAWNERS_TRIAL_CHAMBER_KEY_POOLS: &[LootPool] = &[LootPool {
     entries: SPAWNERS_TRIAL_CHAMBER_KEY_POOL0_ENTRIES,
@@ -39389,6 +44823,8 @@ static TILL_ROOTED_DIRT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     max_count: 1i32,
     condition: LootCondition::None,
     bonus_formula: None,
+    limit: None,
+    explosion_decay: false,
 }];
 static TILL_ROOTED_DIRT_POOLS: &[LootPool] = &[LootPool {
     entries: TILL_ROOTED_DIRT_POOL0_ENTRIES,

--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -33858,14 +33858,34 @@ static ENTITIES_CHICKEN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
-static ENTITIES_CHICKEN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:chicken",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_CHICKEN_POOL1_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_chicken",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:chicken",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_CHICKEN_POOLS: &[LootPool] = &[
     LootPool {
         entries: ENTITIES_CHICKEN_POOL0_ENTRIES,
@@ -33885,14 +33905,34 @@ static ENTITIES_CHICKEN_POOLS: &[LootPool] = &[
 pub static ENTITIES_CHICKEN: LootTable = LootTable {
     pools: ENTITIES_CHICKEN_POOLS,
 };
-static ENTITIES_COD_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cod",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static ENTITIES_COD_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_cod",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:cod",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: None,
+    },
+];
 static ENTITIES_COD_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone_meal",
     weight: 1i32,
@@ -33946,14 +33986,34 @@ static ENTITIES_COW_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
-static ENTITIES_COW_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:beef",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 3i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_COW_POOL1_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_beef",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:beef",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_COW_POOLS: &[LootPool] = &[
     LootPool {
         entries: ENTITIES_COW_POOL0_ENTRIES,
@@ -34096,20 +34156,49 @@ static ENTITIES_CREEPER_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::KillerType {
+            types: &[
+                "minecraft:skeleton",
+                "minecraft:stray",
+                "minecraft:wither_skeleton",
+                "minecraft:skeleton_horse",
+                "minecraft:bogged",
+                "minecraft:parched",
+            ],
+        },
     },
 ];
 pub static ENTITIES_CREEPER: LootTable = LootTable {
     pools: ENTITIES_CREEPER_POOLS,
 };
-static ENTITIES_DOLPHIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:cod",
-    weight: 1i32,
-    min_count: 0i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_DOLPHIN_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_cod",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:cod",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_DOLPHIN_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_DOLPHIN_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -34190,11 +34279,29 @@ static ENTITIES_ELDER_GUARDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
 }];
 static ENTITIES_ELDER_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
+        item: "minecraft:cooked_cod",
+        weight: 3i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
         item: "minecraft:cod",
         weight: 3i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
     },
     LootEntry {
@@ -34458,11 +34565,29 @@ static ENTITIES_GUARDIAN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
 }];
 static ENTITIES_GUARDIAN_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
+        item: "minecraft:cooked_cod",
+        weight: 2i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
         item: "minecraft:cod",
         weight: 2i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
     },
     LootEntry {
@@ -34545,14 +34670,34 @@ static ENTITIES_HAPPY_GHAST_POOLS: &[LootPool] = &[];
 pub static ENTITIES_HAPPY_GHAST: LootTable = LootTable {
     pools: ENTITIES_HAPPY_GHAST_POOLS,
 };
-static ENTITIES_HOGLIN_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:porkchop",
-    weight: 1i32,
-    min_count: 2i32,
-    max_count: 4i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_HOGLIN_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_porkchop",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 4i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:porkchop",
+        weight: 1i32,
+        min_count: 2i32,
+        max_count: 4i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_HOGLIN_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:leather",
     weight: 1i32,
@@ -34632,11 +34777,29 @@ static ENTITIES_HUSK_POOL2_ENTRIES: &[LootEntry] = &[
         bonus_formula: None,
     },
     LootEntry {
+        item: "minecraft:baked_potato",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
         item: "minecraft:potato",
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: None,
     },
 ];
@@ -34786,14 +34949,34 @@ static ENTITIES_MOOSHROOM_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
-static ENTITIES_MOOSHROOM_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:beef",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 3i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_MOOSHROOM_POOL1_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_beef",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:beef",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_MOOSHROOM_POOLS: &[LootPool] = &[
     LootPool {
         entries: ENTITIES_MOOSHROOM_POOL0_ENTRIES,
@@ -34964,14 +35147,34 @@ static ENTITIES_PHANTOM_POOLS: &[LootPool] = &[LootPool {
 pub static ENTITIES_PHANTOM: LootTable = LootTable {
     pools: ENTITIES_PHANTOM_POOLS,
 };
-static ENTITIES_PIG_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:porkchop",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 3i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_PIG_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_porkchop",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:porkchop",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 3i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_PIG_POOLS: &[LootPool] = &[LootPool {
     entries: ENTITIES_PIG_POOL0_ENTRIES,
     min_rolls: 1i32,
@@ -35014,11 +35217,42 @@ pub static ENTITIES_PLAYER: LootTable = LootTable {
 };
 static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
     LootEntry {
+        item: "minecraft:cooked_cod",
+        weight: 3i32,
+        min_count: 0i32,
+        max_count: 2i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
         item: "minecraft:cod",
         weight: 3i32,
         min_count: 0i32,
         max_count: 2i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:cooked_salmon",
+        weight: 1i32,
+        min_count: 0i32,
+        max_count: 2i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
     },
     LootEntry {
@@ -35026,7 +35260,12 @@ static ENTITIES_POLAR_BEAR_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 0i32,
         max_count: 2i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
     },
 ];
@@ -35083,14 +35322,34 @@ static ENTITIES_RABBIT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     condition: LootCondition::None,
     bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
-static ENTITIES_RABBIT_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:rabbit",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_RABBIT_POOL1_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_rabbit",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:rabbit",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_RABBIT_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:rabbit_foot",
     weight: 1i32,
@@ -35150,14 +35409,34 @@ static ENTITIES_RAVAGER_POOLS: &[LootPool] = &[LootPool {
 pub static ENTITIES_RAVAGER: LootTable = LootTable {
     pools: ENTITIES_RAVAGER_POOLS,
 };
-static ENTITIES_SALMON_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:salmon",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
-    condition: LootCondition::None,
-    bonus_formula: None,
-}];
+static ENTITIES_SALMON_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_salmon",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
+        item: "minecraft:salmon",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: None,
+    },
+];
 static ENTITIES_SALMON_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:bone_meal",
     weight: 1i32,
@@ -35185,14 +35464,34 @@ static ENTITIES_SALMON_POOLS: &[LootPool] = &[
 pub static ENTITIES_SALMON: LootTable = LootTable {
     pools: ENTITIES_SALMON_POOLS,
 };
-static ENTITIES_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
-    item: "minecraft:mutton",
-    weight: 1i32,
-    min_count: 1i32,
-    max_count: 2i32,
-    condition: LootCondition::None,
-    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
-}];
+static ENTITIES_SHEEP_POOL0_ENTRIES: &[LootEntry] = &[
+    LootEntry {
+        item: "minecraft:cooked_mutton",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 2i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+    LootEntry {
+        item: "minecraft:mutton",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 2i32,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
+        bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
+    },
+];
 static ENTITIES_SHEEP_POOL1_ENTRIES: &[LootEntry] = &[
     LootEntry {
         item: "minecraft:white_wool",
@@ -36218,11 +36517,29 @@ static ENTITIES_ZOMBIE_POOL2_ENTRIES: &[LootEntry] = &[
         bonus_formula: None,
     },
     LootEntry {
+        item: "minecraft:baked_potato",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
         item: "minecraft:potato",
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: None,
     },
 ];
@@ -36336,11 +36653,29 @@ static ENTITIES_ZOMBIE_VILLAGER_POOL1_ENTRIES: &[LootEntry] = &[
         bonus_formula: None,
     },
     LootEntry {
+        item: "minecraft:baked_potato",
+        weight: 1i32,
+        min_count: 1i32,
+        max_count: 1i32,
+        condition: LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ]),
+        bonus_formula: None,
+    },
+    LootEntry {
         item: "minecraft:potato",
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::Inverted(&LootCondition::AnyOf(&[
+            LootCondition::ThisOnFire,
+            LootCondition::ToolEnchanted {
+                enchantments: &["minecraft:fire_aspect"],
+            },
+        ])),
         bonus_formula: None,
     },
 ];

--- a/crates/pumpkin-util/src/loot_table.rs
+++ b/crates/pumpkin-util/src/loot_table.rs
@@ -21,6 +21,14 @@ pub enum LootCondition {
     TableBonus {
         chances: &'static [f32],
     },
+    /// Matches when the broken block's state has all of these property values.
+    BlockStateProperty {
+        properties: &'static [(&'static str, &'static str)],
+    },
+    /// Matches when the inner condition doesn't.
+    Inverted(&'static Self),
+    /// Matches when any of the inner conditions does.
+    AnyOf(&'static [Self]),
     AllOf(&'static [Self]),
 }
 

--- a/crates/pumpkin-util/src/loot_table.rs
+++ b/crates/pumpkin-util/src/loot_table.rs
@@ -65,6 +65,11 @@ pub struct LootEntry {
     pub condition: LootCondition,
     /// Bonus formula to apply with fortune / looting (if any).
     pub bonus_formula: Option<LootBonusFormula>,
+    /// Clamps the final count after bonuses (vanilla `limit_count`).
+    pub limit: Option<(i32, i32)>,
+    /// Whether each item only survives an explosion with a `1 / radius` chance (vanilla
+    /// `explosion_decay`).
+    pub explosion_decay: bool,
 }
 
 /// One roll pool inside a loot table.

--- a/crates/pumpkin-util/src/loot_table.rs
+++ b/crates/pumpkin-util/src/loot_table.rs
@@ -29,6 +29,16 @@ pub enum LootCondition {
     Inverted(&'static Self),
     /// Matches when any of the inner conditions does.
     AnyOf(&'static [Self]),
+    /// Matches when the entity that drops the loot is on fire.
+    ThisOnFire,
+    /// Matches when the killer's entity type is one of these ids.
+    KillerType {
+        types: &'static [&'static str],
+    },
+    /// Matches when the tool (the attacker's main hand) has one of these enchantments.
+    ToolEnchanted {
+        enchantments: &'static [&'static str],
+    },
     AllOf(&'static [Self]),
 }
 

--- a/crates/pumpkin/src/block/blocks/dripstone.rs
+++ b/crates/pumpkin/src/block/blocks/dripstone.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use crate::{
     block::{
-        BlockBehaviour, BrokenArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, OnPlaceArgs,
-        PathComputationType, PlacedArgs,
+        BlockBehaviour, BrokenArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
+        OnLandedUponArgs, OnPlaceArgs, PathComputationType, PlacedArgs,
     },
     entity::player::Player,
     world::World,
@@ -11,6 +11,7 @@ use crate::{
 use pumpkin_data::{
     Block, BlockDirection, BlockState, BlockStateId,
     block_properties::{PointedDripstoneLikeProperties, SpeleothemThickness, VerticalDirection},
+    damage::DamageType,
 };
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
@@ -20,6 +21,28 @@ use pumpkin_world::world::{BlockAccessor, BlockFlags};
 pub struct DripstoneBlock;
 
 impl BlockBehaviour for DripstoneBlock {
+    fn on_landed_upon(&self, args: OnLandedUponArgs<'_>) {
+        let Some(living) = args.entity.get_living_entity() else {
+            return;
+        };
+        let props = PointedDripstoneLikeProperties::from_state_id(
+            args.world.get_block_state_id(args.position),
+        );
+        // Like vanilla, landing on the tip of a stalagmite deals extra stalagmite damage.
+        if props.vertical_direction == VerticalDirection::Up
+            && props.thickness == SpeleothemThickness::Tip
+        {
+            living.handle_fall_damage_from(
+                args.entity,
+                args.fall_distance + 2.5,
+                2.0,
+                DamageType::STALAGMITE,
+            );
+        } else {
+            living.handle_fall_damage(args.entity, args.fall_distance, 1.0);
+        }
+    }
+
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
         can_place_at_pos(
             args.block_accessor,

--- a/crates/pumpkin/src/block/mod.rs
+++ b/crates/pumpkin/src/block/mod.rs
@@ -358,6 +358,7 @@ pub struct PlayerPlacedArgs<'a> {
 
 pub struct OnLandedUponArgs<'a> {
     pub world: &'a Arc<World>,
+    pub position: &'a BlockPos,
     pub fall_distance: f32,
     pub entity: &'a dyn EntityBase,
 }

--- a/crates/pumpkin/src/block/registry.rs
+++ b/crates/pumpkin/src/block/registry.rs
@@ -1168,6 +1168,7 @@ impl BlockRegistry {
         &self,
         block: &Block,
         world: &Arc<World>,
+        position: &BlockPos,
         fall_distance: f32,
         entity: &dyn EntityBase,
     ) {
@@ -1175,6 +1176,7 @@ impl BlockRegistry {
         if let Some(pumpkin_block) = pumpkin_block {
             pumpkin_block.on_landed_upon(OnLandedUponArgs {
                 world,
+                position,
                 fall_distance,
                 entity,
             });

--- a/crates/pumpkin/src/entity/falling.rs
+++ b/crates/pumpkin/src/entity/falling.rs
@@ -1,7 +1,10 @@
 use pumpkin_data::Block;
+use pumpkin_data::BlockState;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::tag::{self, Taggable};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
@@ -69,7 +72,29 @@ impl EntityBase for FallingEntity {
             {
                 state_id = concrete.default_state.id;
             }
-            world.set_block_state(&landing_pos, state_id, BlockFlags::NOTIFY_ALL);
+            // Like vanilla, only land where the current block can be replaced and the falling
+            // block can survive; otherwise drop it as an item instead of replacing e.g. a torch
+            // or a slab.
+            let landed_block = Block::from_state_id(state_id);
+            let can_land = world.get_block_state(&landing_pos).replaceable()
+                && world.block_registry.can_place_at(
+                    None,
+                    Some(&**world),
+                    &**world,
+                    None,
+                    landed_block,
+                    BlockState::from_id(state_id),
+                    &landing_pos,
+                    None,
+                    None,
+                );
+            if can_land {
+                world.set_block_state(&landing_pos, state_id, BlockFlags::NOTIFY_ALL);
+            } else if world.level_info.load().game_rules.entity_drops
+                && let Some(item) = Item::from_registry_key(landed_block.name)
+            {
+                world.drop_stack(&landing_pos, ItemStack::new(1, item));
+            }
             self.entity.remove();
         }
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1707,11 +1707,13 @@ impl LivingEntity {
                 return;
             }
             let world = self.entity.world.load();
-            let block = world.get_block(&self.entity.get_pos_with_y_offset(0.2).0);
+            let landing_pos = self.entity.get_pos_with_y_offset(0.2).0;
+            let block = world.get_block(&landing_pos);
             let pumpkin_block = world.block_registry.get_pumpkin_block(block.id);
             if let Some(pumpkin_block) = pumpkin_block {
                 pumpkin_block.on_landed_upon(OnLandedUponArgs {
                     world: &world,
+                    position: &landing_pos,
                     fall_distance,
                     entity: caller,
                 });
@@ -1736,6 +1738,17 @@ impl LivingEntity {
         caller: &dyn EntityBase,
         fall_distance: f32,
         damage_per_distance: f32,
+    ) {
+        self.handle_fall_damage_from(caller, fall_distance, damage_per_distance, DamageType::FALL);
+    }
+
+    /// Like [`Self::handle_fall_damage`], but with the damage type to deal (e.g. stalagmites).
+    pub fn handle_fall_damage_from(
+        &self,
+        caller: &dyn EntityBase,
+        fall_distance: f32,
+        damage_per_distance: f32,
+        damage_type: DamageType,
     ) {
         let may_fly = caller.get_player().is_some_and(|player| {
             player
@@ -1763,7 +1776,7 @@ impl LivingEntity {
 
         let damage = (unsafe_fall_distance * damage_per_distance).floor();
         if damage > 0.0 {
-            let check_damage = self.damage(caller, damage, DamageType::FALL); // Fall
+            let check_damage = self.damage(caller, damage, damage_type);
             if check_damage {
                 self.entity
                     .play_sound(Self::get_fall_sound(fall_distance as i32));

--- a/crates/pumpkin/src/world/loot.rs
+++ b/crates/pumpkin/src/world/loot.rs
@@ -87,6 +87,18 @@ fn check_condition(
         LootCondition::AnyOf(conditions) => conditions
             .iter()
             .any(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),
+        LootCondition::ThisOnFire => params.is_on_fire.unwrap_or(false),
+        LootCondition::KillerType { types } => params.killer_entity.is_some_and(|killer| {
+            types
+                .iter()
+                .any(|name| EntityType::from_name(name).is_some_and(|t| t.id == killer.id))
+        }),
+        LootCondition::ToolEnchanted { enchantments } => params.tool.as_ref().is_some_and(|tool| {
+            enchantments.iter().any(|name| {
+                pumpkin_data::Enchantment::from_name(name)
+                    .is_some_and(|e| tool.get_enchantment_level(e) > 0)
+            })
+        }),
         LootCondition::AllOf(conditions) => conditions
             .iter()
             .all(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),
@@ -422,5 +434,63 @@ mod tests {
             .filter(|(id, _)| *id == Item::WHEAT.id)
             .count();
         assert_eq!(wheat_drops, 16);
+    }
+
+    /// Items an entity drops over 16 seeds.
+    fn entity_drops(key: &str, params: &LootContextParameters) -> Vec<&'static Item> {
+        let table = get_loot_table(key).expect("entity has a loot table");
+        (0..16)
+            .flat_map(|seed| generate_loot_with_context(table, seed, params))
+            .map(|stack| stack.item)
+            .collect()
+    }
+
+    fn is_music_disc(item: &Item) -> bool {
+        item.registry_key.contains("music_disc")
+    }
+
+    #[test]
+    fn creepers_only_drop_music_discs_when_killed_by_skeletons() {
+        let by_player = LootContextParameters {
+            killer_entity: Some(&EntityType::PLAYER),
+            ..Default::default()
+        };
+        let drops = entity_drops("minecraft:entities/creeper", &by_player);
+        assert!(!drops.iter().any(|item| is_music_disc(item)));
+
+        let by_skeleton = LootContextParameters {
+            killer_entity: Some(&EntityType::SKELETON),
+            ..Default::default()
+        };
+        let drops = entity_drops("minecraft:entities/creeper", &by_skeleton);
+        assert_eq!(drops.iter().filter(|item| is_music_disc(item)).count(), 16);
+    }
+
+    #[test]
+    fn burning_cows_drop_cooked_beef() {
+        let normal = LootContextParameters {
+            is_on_fire: Some(false),
+            ..Default::default()
+        };
+        let drops = entity_drops("minecraft:entities/cow", &normal);
+        assert_eq!(
+            drops.iter().filter(|item| item.id == Item::BEEF.id).count(),
+            16
+        );
+        assert!(!drops.iter().any(|item| item.id == Item::COOKED_BEEF.id));
+
+        let burning = LootContextParameters {
+            is_on_fire: Some(true),
+            ..Default::default()
+        };
+        let drops = entity_drops("minecraft:entities/cow", &burning);
+        assert_eq!(
+            drops
+                .iter()
+                .filter(|item| item.id == Item::COOKED_BEEF.id)
+                .count(),
+            16
+        );
+        assert!(!drops.iter().any(|item| item.id == Item::BEEF.id));
     }
 }

--- a/crates/pumpkin/src/world/loot.rs
+++ b/crates/pumpkin/src/world/loot.rs
@@ -105,6 +105,32 @@ fn check_condition(
     }
 }
 
+/// Applies `limit_count` and `explosion_decay` to a rolled count.
+fn apply_limit_and_explosion_decay(
+    entry: &LootEntry,
+    mut count: i32,
+    params: &LootContextParameters,
+    rng: &mut Xoroshiro,
+) -> i32 {
+    if let Some((min, max)) = entry.limit {
+        count = count.max(min).min(max);
+    }
+    if entry.explosion_decay
+        && let Some(radius) = params.explosion_radius
+    {
+        // Like vanilla, each item survives the explosion with a 1 / radius chance.
+        let chance = 1.0 / radius;
+        let mut kept = 0;
+        for _ in 0..count {
+            if rng.next_f32() <= chance {
+                kept += 1;
+            }
+        }
+        count = kept;
+    }
+    count
+}
+
 fn apply_bonus_formula(
     base_count: i32,
     bonus: LootBonusFormula,
@@ -247,6 +273,8 @@ pub fn generate_loot_with_context(
                         final_count =
                             apply_bonus_formula(final_count, bonus, fortune_level, &mut rng);
                     }
+                    final_count =
+                        apply_limit_and_explosion_decay(entry, final_count, params, &mut rng);
 
                     if final_count > 0 {
                         let item_key = entry.item.strip_prefix("minecraft:").unwrap_or(entry.item);
@@ -492,5 +520,41 @@ mod tests {
             16
         );
         assert!(!drops.iter().any(|item| item.id == Item::BEEF.id));
+    }
+
+    /// Glowstone dust counts over 16 seeds.
+    fn glowstone_drops(params: &LootContextParameters) -> Vec<u8> {
+        let table =
+            get_loot_table("minecraft:blocks/glowstone").expect("glowstone has a loot table");
+        (0..16)
+            .flat_map(|seed| generate_loot_with_context(table, seed, params))
+            .map(|stack| stack.item_count)
+            .collect()
+    }
+
+    #[test]
+    fn fortune_respects_limit_count() {
+        let mut tool = ItemStack::new(1, &Item::DIAMOND_PICKAXE);
+        tool.enchant(&pumpkin_data::Enchantment::FORTUNE, 3);
+        let params = LootContextParameters {
+            tool: Some(tool),
+            ..Default::default()
+        };
+        let counts = glowstone_drops(&params);
+        assert_eq!(counts.len(), 16);
+        assert!(counts.iter().all(|count| (1..=4).contains(count)));
+    }
+
+    #[test]
+    fn explosions_decay_block_drops() {
+        let params = LootContextParameters {
+            explosion_radius: Some(1.0e6),
+            ..Default::default()
+        };
+        let total: u32 = glowstone_drops(&params)
+            .iter()
+            .map(|count| u32::from(*count))
+            .sum();
+        assert!(total <= 1);
     }
 }

--- a/crates/pumpkin/src/world/loot.rs
+++ b/crates/pumpkin/src/world/loot.rs
@@ -1,3 +1,4 @@
+use pumpkin_data::Block;
 use pumpkin_data::BlockState;
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
@@ -65,6 +66,27 @@ fn check_condition(
                 .get(index)
                 .is_some_and(|chance| rng.next_f32() < *chance)
         }
+        LootCondition::BlockStateProperty { properties } => {
+            params.block_state.is_some_and(|state| {
+                Block::from_state_id(state.id)
+                    .properties(state.id)
+                    .is_some_and(|props| {
+                        let props = props.to_props();
+                        properties.iter().all(|wanted| props.contains(wanted))
+                    })
+            })
+        }
+        LootCondition::Inverted(inner) => !check_condition(
+            *inner,
+            has_silk_touch,
+            has_shears,
+            fortune_level,
+            params,
+            rng,
+        ),
+        LootCondition::AnyOf(conditions) => conditions
+            .iter()
+            .any(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),
         LootCondition::AllOf(conditions) => conditions
             .iter()
             .all(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),
@@ -311,5 +333,94 @@ fn shuffle_and_split_items(
     for i in (1..n).rev() {
         let j = rng.next_bounded_i32((i + 1) as i32) as usize;
         result.swap(i, j);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_data::Block;
+    use pumpkin_data::loot_table::get_loot_table;
+
+    fn state_with(block: &Block, name: &str, value: &str) -> &'static BlockState {
+        block
+            .states
+            .iter()
+            .find(|state| {
+                block.properties(state.id).is_some_and(|props| {
+                    props
+                        .to_props()
+                        .iter()
+                        .any(|(key, val)| *key == name && *val == value)
+                })
+            })
+            .expect("block has a state with this property value")
+    }
+
+    /// Returns `(item id, count)` for every stack the block drops in `state`, over 16 seeds.
+    fn drops(block: &Block, state: &'static BlockState) -> Vec<(u16, u8)> {
+        let table = get_loot_table(&format!("minecraft:blocks/{}", block.name))
+            .expect("block has a loot table");
+        let params = LootContextParameters {
+            block_state: Some(state),
+            ..Default::default()
+        };
+        (0..16)
+            .flat_map(|seed| generate_loot_with_context(table, seed, &params))
+            .map(|stack| (stack.item.id, stack.item_count))
+            .collect()
+    }
+
+    #[test]
+    fn composter_drops_bone_meal_only_when_full() {
+        let composter = &Block::COMPOSTER;
+        let empty = drops(composter, state_with(composter, "level", "0"));
+        assert!(empty.iter().all(|(id, _)| *id == Item::COMPOSTER.id));
+
+        let full = drops(composter, state_with(composter, "level", "8"));
+        let bone_meal = full
+            .iter()
+            .filter(|(id, _)| *id == Item::BONE_MEAL.id)
+            .count();
+        assert_eq!(bone_meal, 16);
+    }
+
+    #[test]
+    fn sweet_berry_bush_drops_depend_on_age() {
+        let bush = &Block::SWEET_BERRY_BUSH;
+        assert!(drops(bush, state_with(bush, "age", "0")).is_empty());
+
+        let ripe = drops(bush, state_with(bush, "age", "3"));
+        assert_eq!(ripe.len(), 16);
+        assert!(
+            ripe.iter()
+                .all(|(id, count)| *id == Item::SWEET_BERRIES.id && (2..=3).contains(count))
+        );
+    }
+
+    #[test]
+    fn only_double_slabs_drop_two() {
+        let slab = &Block::OAK_SLAB;
+        let single = drops(slab, state_with(slab, "type", "bottom"));
+        assert_eq!(single.len(), 16);
+        assert!(single.iter().all(|(_, count)| *count == 1));
+
+        let double = drops(slab, state_with(slab, "type", "double"));
+        assert_eq!(double.len(), 16);
+        assert!(double.iter().all(|(_, count)| *count == 2));
+    }
+
+    #[test]
+    fn wheat_drops_wheat_only_when_mature() {
+        let wheat = &Block::WHEAT;
+        let young = drops(wheat, state_with(wheat, "age", "0"));
+        assert!(young.iter().all(|(id, _)| *id != Item::WHEAT.id));
+
+        let mature = drops(wheat, state_with(wheat, "age", "7"));
+        let wheat_drops = mature
+            .iter()
+            .filter(|(id, _)| *id == Item::WHEAT.id)
+            .count();
+        assert_eq!(wheat_drops, 16);
     }
 }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -6356,7 +6356,12 @@ impl World {
 
         if new_state_id != block_state_id {
             if is_air(new_state_id) {
-                self.break_block(block_pos, None, flags | BlockFlags::NOTIFY_ALL);
+                // Like vanilla, suppressed drops don't carry over to blocks that lose support.
+                self.break_block(
+                    block_pos,
+                    None,
+                    flags.difference(BlockFlags::SKIP_DROPS) | BlockFlags::NOTIFY_ALL,
+                );
             } else {
                 self.set_block_state(block_pos, new_state_id, flags);
             }

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -76,6 +76,8 @@ struct PredicateStruct {
     items: Option<serde_json::Value>,
     #[serde(default)]
     predicates: Option<serde_json::Value>,
+    #[serde(flatten)]
+    other: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -114,6 +116,8 @@ struct ConditionStruct {
     terms: Option<Vec<ConditionStruct>>,
     #[serde(default)]
     properties: Option<serde_json::Map<String, serde_json::Value>>,
+    #[serde(default)]
+    entity: Option<String>,
 }
 
 fn parse_condition(cond: &ConditionStruct) -> LootCondition {
@@ -175,6 +179,7 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
                 }
             }
         }
+        "minecraft:entity_properties" => parse_entity_properties(cond),
         "minecraft:all_of" => {
             if let Some(terms) = &cond.terms {
                 combine_conditions(terms)
@@ -285,7 +290,10 @@ fn is_deterministic(cond: LootCondition) -> bool {
         | LootCondition::SilkTouchOrShears
         | LootCondition::NoSilkTouchOrShears
         | LootCondition::KilledByPlayer
-        | LootCondition::BlockStateProperty { .. } => true,
+        | LootCondition::BlockStateProperty { .. }
+        | LootCondition::ThisOnFire
+        | LootCondition::KillerType { .. }
+        | LootCondition::ToolEnchanted { .. } => true,
         LootCondition::Inverted(inner) => is_deterministic(*inner),
         LootCondition::AllOf(list) | LootCondition::AnyOf(list) => {
             list.iter().copied().all(is_deterministic)
@@ -363,6 +371,192 @@ fn push_count_variants(
     let mut parts = vec![condition];
     parts.extend(later.iter().copied().map(invert));
     push(all_of(parts), (1, 1));
+}
+
+fn leak_list(values: Vec<String>) -> &'static [&'static str] {
+    let values: Vec<&'static str> = values.iter().map(|v| leak_str(v)).collect();
+    Box::leak(values.into_boxed_slice())
+}
+
+/// Expands `#namespace:tag` into its values (recursively); a plain id is returned as-is.
+fn expand_tag(registry: &str, id: &str) -> Vec<String> {
+    let Some(tag) = id.strip_prefix('#') else {
+        return vec![id.to_owned()];
+    };
+    let name = tag.strip_prefix("minecraft:").unwrap_or(tag);
+    let path = Path::new("../../assets/datapacks/26_2/data/minecraft/tags")
+        .join(registry)
+        .join(format!("{name}.json"));
+    let Ok(content) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return Vec::new();
+    };
+    json.get("values")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|v| {
+            v.as_str()
+                .or_else(|| v.get("id").and_then(serde_json::Value::as_str))
+        })
+        .flat_map(|v| expand_tag(registry, v))
+        .collect()
+}
+
+/// Supports the `entity_properties` checks vanilla uses for cooked drops and for creeper
+/// music discs. Anything else stays unconditional, like before.
+fn parse_entity_properties(cond: &ConditionStruct) -> LootCondition {
+    let Some(pred) = &cond.predicate else {
+        return LootCondition::None;
+    };
+    // Only predicates with exactly one known check, so nothing gets silently ignored.
+    if pred.items.is_some() || pred.predicates.is_some() || pred.other.len() != 1 {
+        return LootCondition::None;
+    }
+    let Some((key, value)) = pred.other.iter().next() else {
+        return LootCondition::None;
+    };
+    match (cond.entity.as_deref(), key.as_str()) {
+        (Some("this"), "minecraft:flags")
+            if value.as_object().is_some_and(|flags| flags.len() == 1)
+                && value.get("is_on_fire") == Some(&serde_json::Value::Bool(true)) =>
+        {
+            LootCondition::ThisOnFire
+        }
+        (Some("attacker"), "minecraft:entity_type") => {
+            let types = value
+                .as_str()
+                .map(|id| expand_tag("entity_type", id))
+                .unwrap_or_default();
+            if types.is_empty() {
+                LootCondition::None
+            } else {
+                LootCondition::KillerType {
+                    types: leak_list(types),
+                }
+            }
+        }
+        (Some("direct_attacker"), "minecraft:equipment") => parse_mainhand_enchantments(value),
+        _ => LootCondition::None,
+    }
+}
+
+/// Parses `{"mainhand": {"predicates": {"minecraft:enchantments": [{"enchantments": ..}]}}}`.
+fn parse_mainhand_enchantments(equipment: &serde_json::Value) -> LootCondition {
+    let single = |v: &serde_json::Value, key: &str| {
+        v.as_object()
+            .filter(|o| o.len() == 1)
+            .and_then(|o| o.get(key))
+            .cloned()
+    };
+    let Some(list) = single(equipment, "mainhand")
+        .and_then(|mainhand| single(&mainhand, "predicates"))
+        .and_then(|predicates| single(&predicates, "minecraft:enchantments"))
+    else {
+        return LootCondition::None;
+    };
+    let mut enchantments = Vec::new();
+    for entry in list.as_array().into_iter().flatten() {
+        // Level requirements aren't supported.
+        let Some(id) = single(entry, "enchantments") else {
+            return LootCondition::None;
+        };
+        let Some(id) = id.as_str() else {
+            return LootCondition::None;
+        };
+        enchantments.extend(expand_tag("enchantment", id));
+    }
+    if enchantments.is_empty() {
+        LootCondition::None
+    } else {
+        LootCondition::ToolEnchanted {
+            enchantments: leak_list(enchantments),
+        }
+    }
+}
+
+/// Raw item → smelted result, from the vanilla smelting recipes.
+fn smelting_result(item: &str) -> Option<String> {
+    static RECIPES: std::sync::OnceLock<std::collections::HashMap<String, String>> =
+        std::sync::OnceLock::new();
+    RECIPES
+        .get_or_init(|| {
+            let mut map = std::collections::HashMap::new();
+            let dir = Path::new("../../assets/datapacks/26_2/data/minecraft/recipe");
+            for entry in fs::read_dir(dir).into_iter().flatten().flatten() {
+                let Ok(content) = fs::read_to_string(entry.path()) else {
+                    continue;
+                };
+                let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+                    continue;
+                };
+                if json.get("type").and_then(serde_json::Value::as_str)
+                    != Some("minecraft:smelting")
+                {
+                    continue;
+                }
+                if let (Some(ingredient), Some(result)) = (
+                    json.get("ingredient").and_then(serde_json::Value::as_str),
+                    json.get("result")
+                        .and_then(|r| r.get("id"))
+                        .and_then(serde_json::Value::as_str),
+                ) {
+                    map.insert(ingredient.to_owned(), result.to_owned());
+                }
+            }
+            map
+        })
+        .get(item)
+        .cloned()
+}
+
+/// Emits cooked and raw variants for `furnace_smelt`, whose condition (e.g. "on fire") picks
+/// which one drops. Smelting with a condition that can't be parsed is skipped, like before.
+fn push_smelt_variants(
+    item: &str,
+    weight: i32,
+    condition: LootCondition,
+    bonus_formula: Option<LootBonusFormula>,
+    functions: &[&EntryFunctionStruct],
+    out: &mut Vec<ParsedEntry>,
+) {
+    let smelt = functions
+        .iter()
+        .find(|f| f.function == "minecraft:furnace_smelt")
+        .and_then(|f| {
+            let cooked = smelting_result(item)?;
+            let fully_parsed = f
+                .conditions
+                .iter()
+                .all(|c| parse_condition(c) != LootCondition::None);
+            let smelt_cond = combine_conditions(&f.conditions);
+            (fully_parsed && is_deterministic(smelt_cond)).then_some((smelt_cond, cooked))
+        });
+
+    let Some((smelt_cond, cooked)) = smelt else {
+        push_count_variants(item, weight, condition, bonus_formula, functions, out);
+        return;
+    };
+    push_count_variants(
+        &cooked,
+        weight,
+        all_of(vec![condition, smelt_cond]),
+        bonus_formula,
+        functions,
+        out,
+    );
+    if smelt_cond != LootCondition::None {
+        push_count_variants(
+            item,
+            weight,
+            all_of(vec![condition, invert(smelt_cond)]),
+            bonus_formula,
+            functions,
+            out,
+        );
+    }
 }
 
 fn combine_conditions(conditions: &[ConditionStruct]) -> LootCondition {
@@ -549,7 +743,7 @@ fn extract_entries_with_depth(
                     }
                 });
 
-                push_count_variants(
+                push_smelt_variants(
                     name,
                     entry.weight,
                     entry_cond,
@@ -769,6 +963,13 @@ fn condition_to_tokens(cond: LootCondition) -> TokenStream {
         LootCondition::AnyOf(list) => {
             let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();
             quote! { LootCondition::AnyOf(&[#(#tokens),*]) }
+        }
+        LootCondition::ThisOnFire => quote! { LootCondition::ThisOnFire },
+        LootCondition::KillerType { types } => {
+            quote! { LootCondition::KillerType { types: &[#(#types),*] } }
+        }
+        LootCondition::ToolEnchanted { enchantments } => {
+            quote! { LootCondition::ToolEnchanted { enchantments: &[#(#enchantments),*] } }
         }
         LootCondition::AllOf(list) => {
             let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -325,6 +325,16 @@ fn push_count_variants(
         })
         .collect();
 
+    // `limit_count` and `explosion_decay` apply to every variant. Conditional ones are left out,
+    // like before, since they would need the same splitting as `set_count`.
+    let limit = functions
+        .iter()
+        .filter(|f| f.function == "minecraft:limit_count" && f.conditions.is_empty())
+        .find_map(|f| f.limit.as_ref().map(parse_limit));
+    let explosion_decay = functions
+        .iter()
+        .any(|f| f.function == "minecraft:explosion_decay" && f.conditions.is_empty());
+
     let mut push = |condition: LootCondition, (min_count, max_count): (i32, i32)| {
         out.push(ParsedEntry {
             item: item.to_owned(),
@@ -333,6 +343,8 @@ fn push_count_variants(
             max_count,
             condition,
             bonus_formula,
+            limit,
+            explosion_decay,
         });
     };
 
@@ -559,6 +571,21 @@ fn push_smelt_variants(
     }
 }
 
+/// `limit_count`'s range: a number, or `{"min": .., "max": ..}` with either side optional.
+/// A missing minimum is 0, since counts below that drop nothing anyway.
+fn parse_limit(limit: &serde_json::Value) -> (i32, i32) {
+    if let Some(n) = limit.as_f64() {
+        return (n as i32, n as i32);
+    }
+    let bound = |key: &str, default: i32| {
+        limit
+            .get(key)
+            .and_then(serde_json::Value::as_f64)
+            .map_or(default, |v| v as i32)
+    };
+    (bound("min", 0), bound("max", i32::MAX))
+}
+
 fn combine_conditions(conditions: &[ConditionStruct]) -> LootCondition {
     let mut parsed_list: Vec<LootCondition> = Vec::new();
     for c in conditions {
@@ -594,6 +621,8 @@ struct EntryFunctionStruct {
     count: Option<CountStruct>,
     #[serde(default)]
     conditions: Vec<ConditionStruct>,
+    #[serde(default)]
+    limit: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -644,6 +673,8 @@ fn default_rolls() -> RollsStruct {
 struct ChestLootTableJson {
     #[serde(default)]
     pools: Vec<PoolStruct>,
+    #[serde(default)]
+    functions: Vec<EntryFunctionStruct>,
 }
 
 fn path_to_key(relative: &str) -> String {
@@ -661,6 +692,8 @@ struct ParsedEntry {
     max_count: i32,
     condition: LootCondition,
     bonus_formula: Option<LootBonusFormula>,
+    limit: Option<(i32, i32)>,
+    explosion_decay: bool,
 }
 
 fn extract_entries(
@@ -776,6 +809,8 @@ fn extract_entries_with_depth(
                                 max_count: 1,
                                 condition: entry_cond,
                                 bonus_formula: None,
+                                limit: None,
+                                explosion_decay: false,
                             });
                         }
                     }
@@ -1011,11 +1046,19 @@ fn emit_table(
         let mut parsed_entries = Vec::new();
         let mut empty_weight: i32 = 0;
 
+        // Pool- and table-level functions apply to every entry, after the entry's own.
+        let functions: Vec<EntryFunctionStruct> = pool
+            .functions
+            .iter()
+            .chain(&table.functions)
+            .cloned()
+            .collect();
+
         for entry in &pool.entries {
             extract_entries(
                 entry,
                 LootCondition::None,
-                &pool.functions,
+                &functions,
                 &mut parsed_entries,
                 &mut empty_weight,
             );
@@ -1030,6 +1073,11 @@ fn emit_table(
                 let max_count = e.max_count;
                 let cond_tokens = condition_to_tokens(e.condition);
                 let bonus_tokens = bonus_to_tokens(e.bonus_formula);
+                let limit_tokens = match e.limit {
+                    Some((min, max)) => quote! { Some((#min, #max)) },
+                    None => quote! { None },
+                };
+                let explosion_decay = e.explosion_decay;
 
                 quote! {
                     LootEntry {
@@ -1039,6 +1087,8 @@ fn emit_table(
                         max_count: #max_count,
                         condition: #cond_tokens,
                         bonus_formula: #bonus_tokens,
+                        limit: #limit_tokens,
+                        explosion_decay: #explosion_decay,
                     }
                 }
             })

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -112,6 +112,8 @@ struct ConditionStruct {
     term: Option<Box<ConditionStruct>>,
     #[serde(default)]
     terms: Option<Vec<ConditionStruct>>,
+    #[serde(default)]
+    properties: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 fn parse_condition(cond: &ConditionStruct) -> LootCondition {
@@ -150,6 +152,26 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
             } else {
                 LootCondition::TableBonus {
                     chances: Box::leak(chances.into_boxed_slice()),
+                }
+            }
+        }
+        "minecraft:block_state_property" => {
+            // Only exact values are supported; ranges stay unconditional like before.
+            let Some(properties) = &cond.properties else {
+                return LootCondition::None;
+            };
+            let mut pairs = Vec::new();
+            for (name, value) in properties {
+                let Some(value) = value.as_str() else {
+                    return LootCondition::None;
+                };
+                pairs.push((leak_str(name), leak_str(value)));
+            }
+            if pairs.is_empty() {
+                LootCondition::None
+            } else {
+                LootCondition::BlockStateProperty {
+                    properties: Box::leak(pairs.into_boxed_slice()),
                 }
             }
         }
@@ -198,6 +220,11 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
                 } else if has_shears {
                     return LootCondition::Shears;
                 }
+                let parsed: Vec<LootCondition> = terms.iter().map(parse_condition).collect();
+                // An unsupported term counts as always true, and so would the whole `any_of`.
+                if !parsed.is_empty() && !parsed.contains(&LootCondition::None) {
+                    return LootCondition::AnyOf(Box::leak(parsed.into_boxed_slice()));
+                }
             }
             LootCondition::None
         }
@@ -207,7 +234,8 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
                     LootCondition::SilkTouch => LootCondition::NoSilkTouch,
                     LootCondition::Shears => LootCondition::NoSilkTouchOrShears,
                     LootCondition::SilkTouchOrShears => LootCondition::NoSilkTouchOrShears,
-                    _ => LootCondition::None,
+                    LootCondition::None => LootCondition::None,
+                    other => LootCondition::Inverted(Box::leak(Box::new(other))),
                 }
             } else {
                 LootCondition::None
@@ -215,6 +243,126 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
         }
         _ => LootCondition::None,
     }
+}
+
+fn leak_str(s: &str) -> &'static str {
+    Box::leak(s.to_owned().into_boxed_str())
+}
+
+/// Combines conditions that must all hold, dropping unconditional parts.
+fn all_of(parts: Vec<LootCondition>) -> LootCondition {
+    let mut parts: Vec<LootCondition> = parts
+        .into_iter()
+        .filter(|c| *c != LootCondition::None)
+        .collect();
+    parts.dedup();
+    match parts.len() {
+        0 => LootCondition::None,
+        1 => parts[0],
+        _ => LootCondition::AllOf(Box::leak(parts.into_boxed_slice())),
+    }
+}
+
+fn invert(cond: LootCondition) -> LootCondition {
+    match cond {
+        LootCondition::SilkTouch => LootCondition::NoSilkTouch,
+        LootCondition::NoSilkTouch => LootCondition::SilkTouch,
+        LootCondition::SilkTouchOrShears => LootCondition::NoSilkTouchOrShears,
+        LootCondition::NoSilkTouchOrShears => LootCondition::SilkTouchOrShears,
+        LootCondition::Inverted(inner) => *inner,
+        other => LootCondition::Inverted(Box::leak(Box::new(other))),
+    }
+}
+
+/// Whether a condition gives the same answer every time it is checked, so it can be
+/// negated without re-rolling a random chance.
+fn is_deterministic(cond: LootCondition) -> bool {
+    match cond {
+        LootCondition::None
+        | LootCondition::SilkTouch
+        | LootCondition::NoSilkTouch
+        | LootCondition::Shears
+        | LootCondition::SilkTouchOrShears
+        | LootCondition::NoSilkTouchOrShears
+        | LootCondition::KilledByPlayer
+        | LootCondition::BlockStateProperty { .. } => true,
+        LootCondition::Inverted(inner) => is_deterministic(*inner),
+        LootCondition::AllOf(list) | LootCondition::AnyOf(list) => {
+            list.iter().copied().all(is_deterministic)
+        }
+        LootCondition::SurvivesExplosion
+        | LootCondition::RandomChance { .. }
+        | LootCondition::RandomChanceWithEnchantedBonus { .. }
+        | LootCondition::TableBonus { .. } => false,
+    }
+}
+
+/// Emits one entry per possible `set_count` outcome. A `set_count` with a condition (e.g.
+/// `type=double` on slabs) only applies when it holds, and later ones override earlier ones.
+fn push_count_variants(
+    item: &str,
+    weight: i32,
+    condition: LootCondition,
+    bonus_formula: Option<LootBonusFormula>,
+    functions: &[&EntryFunctionStruct],
+    out: &mut Vec<ParsedEntry>,
+) {
+    let set_counts: Vec<(LootCondition, (i32, i32))> = functions
+        .iter()
+        .filter(|f| f.function == "minecraft:set_count")
+        .filter_map(|f| {
+            f.count
+                .as_ref()
+                .map(|c| (combine_conditions(&f.conditions), (c.min(), c.max())))
+        })
+        .collect();
+
+    let mut push = |condition: LootCondition, (min_count, max_count): (i32, i32)| {
+        out.push(ParsedEntry {
+            item: item.to_owned(),
+            weight,
+            min_count,
+            max_count,
+            condition,
+            bonus_formula,
+        });
+    };
+
+    // An unparsed condition would make its `set_count` look unconditional.
+
+    let all_parsed = functions
+        .iter()
+        .filter(|f| f.function == "minecraft:set_count")
+        .all(|f| {
+            f.conditions
+                .iter()
+                .all(|c| parse_condition(c) != LootCondition::None)
+        });
+
+    if !all_parsed || !set_counts.iter().all(|(c, _)| is_deterministic(*c)) {
+        // Random conditions can't be split without re-rolling: keep the first `set_count`.
+        push(
+            condition,
+            set_counts.first().map_or((1, 1), |(_, count)| *count),
+        );
+        return;
+    }
+
+    // Walk from the last `set_count` backwards: each applies when its condition holds and
+    // none of the later ones do.
+    let mut later: Vec<LootCondition> = Vec::new();
+    for (set_condition, count) in set_counts.iter().rev() {
+        let mut parts = vec![condition, *set_condition];
+        parts.extend(later.iter().copied().map(invert));
+        push(all_of(parts), *count);
+        if *set_condition == LootCondition::None {
+            return;
+        }
+        later.push(*set_condition);
+    }
+    let mut parts = vec![condition];
+    parts.extend(later.iter().copied().map(invert));
+    push(all_of(parts), (1, 1));
 }
 
 fn combine_conditions(conditions: &[ConditionStruct]) -> LootCondition {
@@ -250,6 +398,8 @@ struct EntryFunctionStruct {
     #[serde(default)]
     parameters: Option<BonusParameterStruct>,
     count: Option<CountStruct>,
+    #[serde(default)]
+    conditions: Vec<ConditionStruct>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -288,6 +438,8 @@ struct PoolStruct {
     rolls: RollsStruct,
     #[serde(default)]
     conditions: Vec<ConditionStruct>,
+    #[serde(default)]
+    functions: Vec<EntryFunctionStruct>,
 }
 
 fn default_rolls() -> RollsStruct {
@@ -320,15 +472,24 @@ struct ParsedEntry {
 fn extract_entries(
     entry: &PoolEntryStruct,
     inherited_condition: LootCondition,
+    pool_functions: &[EntryFunctionStruct],
     out: &mut Vec<ParsedEntry>,
     empty_weight: &mut i32,
 ) {
-    extract_entries_with_depth(entry, inherited_condition, out, empty_weight, 0);
+    extract_entries_with_depth(
+        entry,
+        inherited_condition,
+        pool_functions,
+        out,
+        empty_weight,
+        0,
+    );
 }
 
 fn extract_entries_with_depth(
     entry: &PoolEntryStruct,
     inherited_condition: LootCondition,
+    pool_functions: &[EntryFunctionStruct],
     out: &mut Vec<ParsedEntry>,
     empty_weight: &mut i32,
     depth: usize,
@@ -349,15 +510,11 @@ fn extract_entries_with_depth(
         }
         "minecraft:item" => {
             if let Some(name) = &entry.name {
-                let (min_count, max_count) = entry
-                    .functions
-                    .iter()
-                    .find(|f| f.function == "minecraft:set_count")
-                    .and_then(|f| f.count.as_ref())
-                    .map(|c| (c.min(), c.max()))
-                    .unwrap_or((1, 1));
+                // Pool-level functions apply to every entry in the pool, after the entry's own.
+                let functions: Vec<&EntryFunctionStruct> =
+                    entry.functions.iter().chain(pool_functions).collect();
 
-                let bonus_formula = entry.functions.iter().find_map(|f| {
+                let bonus_formula = functions.iter().find_map(|f| {
                     if f.function == "minecraft:apply_bonus" {
                         match f.formula.as_deref() {
                             Some("minecraft:ore_drops") => Some(LootBonusFormula::OreDrops),
@@ -392,14 +549,14 @@ fn extract_entries_with_depth(
                     }
                 });
 
-                out.push(ParsedEntry {
-                    item: name.clone(),
-                    weight: entry.weight,
-                    min_count,
-                    max_count,
-                    condition: entry_cond,
+                push_count_variants(
+                    name,
+                    entry.weight,
+                    entry_cond,
                     bonus_formula,
-                });
+                    &functions,
+                    out,
+                );
             }
         }
         "minecraft:tag" => {
@@ -450,6 +607,7 @@ fn extract_entries_with_depth(
                                 extract_entries_with_depth(
                                     child_entry,
                                     pool_cond,
+                                    &pool.functions,
                                     out,
                                     empty_weight,
                                     depth + 1,
@@ -472,6 +630,7 @@ fn extract_entries_with_depth(
                         extract_entries_with_depth(
                             child_entry,
                             pool_cond,
+                            &pool.functions,
                             out,
                             empty_weight,
                             depth + 1,
@@ -501,6 +660,7 @@ fn extract_entries_with_depth(
                                     extract_entries_with_depth(
                                         child_entry,
                                         pool_cond,
+                                        &pool.functions,
                                         out,
                                         empty_weight,
                                         depth + 1,
@@ -513,38 +673,53 @@ fn extract_entries_with_depth(
             }
         },
         "minecraft:alternatives" => {
-            let mut saw_silk = false;
-            let mut saw_shears = false;
-
+            // Vanilla uses the first child whose conditions hold, so a later child only applies
+            // when every earlier one fails. Random conditions can't be negated without
+            // re-rolling, so only deterministic ones are excluded.
+            let mut earlier: Vec<LootCondition> = Vec::new();
             for child in &entry.children {
                 let child_cond = combine_conditions(&child.conditions);
-
-                let effective_cond = if child_cond == LootCondition::SilkTouch {
-                    saw_silk = true;
-                    LootCondition::SilkTouch
-                } else if child_cond == LootCondition::Shears {
-                    saw_shears = true;
-                    LootCondition::Shears
-                } else if child_cond == LootCondition::SilkTouchOrShears {
-                    saw_silk = true;
-                    saw_shears = true;
-                    LootCondition::SilkTouchOrShears
-                } else if saw_silk && saw_shears {
-                    LootCondition::NoSilkTouchOrShears
-                } else if saw_silk {
-                    LootCondition::NoSilkTouch
-                } else if saw_shears {
-                    LootCondition::NoSilkTouchOrShears
-                } else {
-                    entry_cond
-                };
-
-                extract_entries_with_depth(child, effective_cond, out, empty_weight, depth + 1);
+                let mut parts = vec![entry_cond];
+                parts.extend(earlier.iter().copied().map(invert));
+                extract_entries_with_depth(
+                    child,
+                    all_of(parts),
+                    pool_functions,
+                    out,
+                    empty_weight,
+                    depth + 1,
+                );
+                if child.conditions.is_empty()
+                    && matches!(
+                        child.entry_type.as_str(),
+                        "minecraft:item" | "minecraft:tag" | "minecraft:empty"
+                    )
+                {
+                    // An unconditional leaf always matches, so later children never run.
+                    break;
+                }
+                // Only exclude conditions that are fully understood: an unparsed one would
+                // become "never" and hide every later child.
+                let fully_parsed = child
+                    .conditions
+                    .iter()
+                    .all(|c| parse_condition(c) != LootCondition::None);
+                if child_cond != LootCondition::None && fully_parsed && is_deterministic(child_cond)
+                {
+                    earlier.push(child_cond);
+                }
             }
         }
         "minecraft:sequence" | "minecraft:group" => {
             for child in &entry.children {
-                extract_entries_with_depth(child, entry_cond, out, empty_weight, depth + 1);
+                extract_entries_with_depth(
+                    child,
+                    entry_cond,
+                    pool_functions,
+                    out,
+                    empty_weight,
+                    depth + 1,
+                );
             }
         }
         _ => {}
@@ -580,6 +755,20 @@ fn condition_to_tokens(cond: LootCondition) -> TokenStream {
         LootCondition::TableBonus { chances } => {
             let values = chances.iter();
             quote! { LootCondition::TableBonus { chances: &[#(#values),*] } }
+        }
+        LootCondition::BlockStateProperty { properties } => {
+            let pairs = properties
+                .iter()
+                .map(|(name, value)| quote! { (#name, #value) });
+            quote! { LootCondition::BlockStateProperty { properties: &[#(#pairs),*] } }
+        }
+        LootCondition::Inverted(inner) => {
+            let inner = condition_to_tokens(*inner);
+            quote! { LootCondition::Inverted(&#inner) }
+        }
+        LootCondition::AnyOf(list) => {
+            let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();
+            quote! { LootCondition::AnyOf(&[#(#tokens),*]) }
         }
         LootCondition::AllOf(list) => {
             let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();
@@ -625,6 +814,7 @@ fn emit_table(
             extract_entries(
                 entry,
                 LootCondition::None,
+                &pool.functions,
                 &mut parsed_entries,
                 &mut empty_weight,
             );
@@ -689,12 +879,13 @@ fn collect_json_files(base: &Path, dir: &Path) -> Vec<(String, ChestLootTableJso
         if path.is_dir() {
             result.extend(collect_json_files(base, &path));
         } else if path.extension().is_some_and(|ext| ext == "json") {
+            // Use '/' on every OS so the keys match the vanilla resource ids.
             let relative = path
                 .strip_prefix(base)
                 .unwrap()
                 .with_extension("")
                 .to_string_lossy()
-                .to_string();
+                .replace('\\', "/");
 
             let content = match fs::read_to_string(&path) {
                 Ok(c) => c,


### PR DESCRIPTION
## Description

Fixes #3293, #3292, #3120, #3377, #3240, #3390, #3153, and the drop part of #3109.

### Loot tables ignored `block_state_property` and other conditions

`tools/pumpkin-codegen/src/loot_table.rs` turned every condition it didn't recognise into `LootCondition::None`, which means "always true". 155 of the 1356 vanilla loot tables use `minecraft:block_state_property` (259 times), so all of those conditions were dropped. Three more flattening problems made it worse:

- **`alternatives` with non-tool conditions.** Every child became eligible at the same time and the pool then picked one at random, e.g. mature wheat gave wheat *or* seeds 50/50.
- **Conditional `set_count` functions.** Their conditions were ignored. Slabs say "count 2 only if `type=double`", so **every broken single slab dropped 2 slabs**.
- **Pool-level `functions`.** These were never read, e.g. the sweet berry bush's `set_count` and Fortune bonus.

Visible results in game:

- Composters dropped bone meal every time they were broken (#3293).
- Sweet berry bushes dropped berries at any age, with the wrong counts (#3292).
- Snow layers dropped a random mix of snowballs, snow blocks and layers (the drop part of #3109).
- Slabs duplicated (1 → 2); both halves of doors, beds and tall plants were eligible to drop; candles and sea pickles ignored their count; crops dropped their produce while still growing.

Changes:

- `pumpkin-util`: new `LootCondition::BlockStateProperty { properties }`, `Inverted(&Self)` and `AnyOf(&[Self])`.
- `world/loot.rs`: evaluates them. `BlockStateProperty` checks the broken block's state, which block breaking and explosions already pass in `LootContextParameters::block_state`.
- Codegen:
  - Parses `block_state_property` (exact values; ranges stay unconditional as before), generic `inverted` and generic `any_of`.
  - `alternatives` now follows vanilla's "first matching child wins": a later child gets the negation of every earlier **deterministic, fully parsed** condition. Random conditions (table bonus, random chance) aren't negated, since that would re-roll them. Conditions the codegen doesn't understand yet (e.g. sheep colour or chicken variant `entity_properties`) aren't negated either, so those tables stay as before; so gravel/flint and leaves/sapling generate exactly the same conditions as before.
  - A `set_count` with deterministic conditions is split into one entry per possible count (slabs, candles, sea pickles, …).
  - Pool-level functions apply to the pool's entries.

### Entity loot: creeper music discs and cooked drops

`entity_properties` conditions were treated as "always true" too, so **every creeper dropped a music disc**, whoever killed it (#3240). `furnace_smelt` was ignored, so mobs killed while burning or with Fire Aspect dropped raw food (#3390).

- New `ThisOnFire`, `KillerType { types }` and `ToolEnchanted { enchantments }` conditions, evaluated from `is_on_fire`, `killer_entity` and the attacker's weapon (`tool`), which the death loot context already fills in.
- The codegen parses the three `entity_properties` shapes vanilla uses for these: `this` + `flags.is_on_fire`, `attacker` + `entity_type`, and `direct_attacker` + main-hand enchantments. Entity type and enchantment tags are expanded. Every other shape stays unconditional, as before.
- `furnace_smelt` emits a cooked and a raw variant, using the vanilla smelting recipes. Smelting is skipped if any of its conditions can't be parsed, so nothing gets cooked by accident.

`loot_table.rs` is regenerated with `cargo run -p pumpkin-codegen -- loot_table`.

### Loot ignored `limit_count` and `explosion_decay`

The codegen also ignored `limit_count` and `explosion_decay`, and never read table-level functions, which is where vanilla usually puts `explosion_decay`. Two effects:

- **Fortune exceeded vanilla's caps:** up to 7 glowstone dust instead of 4, and 10 melon slices instead of 9.
- **Explosions dropped full counts:** blocks destroyed by an explosion dropped everything, instead of each item surviving with a `1 / radius` chance.

The fix:

- `LootEntry` gets `limit` and `explosion_decay`, applied after bonuses.
- Pool- and table-level functions now apply to every entry.
- Conditional ones are left out, as before.

### Blocks that lose support didn't drop after a creative break (#3120)

A creative break passes `SKIP_DROPS`, and `replace_with_state_for_neighbor_update` forwarded the same flags when breaking a torch, lever or button that lost its support. Vanilla clears `UPDATE_SUPPRESS_DROPS` before neighbour shape updates (`Level.setBlock`, `flags & -34`), so those blocks drop. The flag is now removed there. Door, bed and tall-plant halves don't dupe, because the loot tables above now only drop the lower half or the head.

### Landing on a stalagmite did no extra damage (#3377)

Pointed dripstone had no `on_landed_upon`. Like vanilla's `PointedDripstoneBlock.fallOn`, landing on an upward tip now calls `causeFallDamage(fallDistance + 2.5, 2.0, stalagmite)`. `OnLandedUponArgs` gets the landing `position`, and `LivingEntity::handle_fall_damage_from` takes the damage type (`handle_fall_damage` keeps using `FALL`).

### Falling blocks replaced partial blocks (#3153)

A landing falling block always replaced the block at its position. Like vanilla's `FallingBlockEntity`, it now only lands where the current block is replaceable and the falling block can survive, and otherwise drops as an item (when `doEntityDrops` is on).

## Testing

- `cargo clippy --workspace --all-targets --locked`: clean (workspace pedantic + nursery lints).
- `cargo fmt --all --check`: clean.
- `cargo test -p pumpkin -p pumpkin-util`: 307 passed, 0 failed.

- New loot tests in `world/loot.rs`, each over 16 seeds:
  - composter only drops bone meal at level 8;
  - sweet berry bush drops nothing at age 0 and 2–3 berries at age 3;
  - single slabs drop 1, double slabs 2;
  - wheat only drops wheat at age 7;
  - creepers only drop music discs when a skeleton killed them;
  - cows drop cooked beef only when burning;
  - glowstone with Fortune III never drops more than 4 dust;
  - blocks destroyed by a huge explosion drop (almost) nothing.
- Regenerated `loot_table.rs` compared with `master`: leaving aside the two fields every entry gains in the last commit, the entries of 168 of 1312 tables change, namely 151 block tables, 16 entity tables that gain cooked-drop variants and the sweet berry harvest table. The creeper change is in its music-disc pool condition. Oak leaves, gravel, diamond ore and the abandoned mineshaft chest are byte-for-byte identical, as are tables whose conditions the codegen still doesn't understand (charged creeper heads, chicken eggs, sheep and mooshroom shearing).

Built on Windows with `x86_64-pc-windows-gnullvm` + llvm-mingw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded loot-table support for block states, entity conditions, enchanted tools, item limits, and explosion decay.
  * Added more accurate loot generation for smelting, count variations, alternatives, tags, and nested tables.
  * Falling blocks now drop as items when they cannot be placed safely.

* **Bug Fixes**
  * Pointed dripstone now damages living entities that land on upward-facing tips.
  * Blocks losing support now correctly drop items when appropriate.
  * Loot drops now better respect vanilla limits and explosion survival behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->