### PR TITLE
fix(dragon-parts): make the ender dragon hittable and stop it despawning

### DIFF
--- a/crates/pumpkin/src/block/entities/piston.rs
+++ b/crates/pumpkin/src/block/entities/piston.rs
@@ -129,7 +129,6 @@ impl PistonBlockEntity {
     fn move_entity(entity: &crate::entity::Entity, dir: BlockDirection, distance: f64) {
         let new_pos = entity.pos.load() + Self::dir_vec(dir, distance);
         entity.set_pos(new_pos);
-        entity.send_pos();
     }
 
     /// Vanilla `push`: when a piston head retracts, shove entities that ended up

--- a/crates/pumpkin/src/entity/boss/ender_dragon.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon.rs
@@ -1,6 +1,8 @@
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::{Block, BlockStateId};
+use pumpkin_util::math::boundingbox::{BoundingBox, EntityDimensions};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_world::{chunk::ChunkHeightmapType, world::BlockFlags};
@@ -141,16 +143,42 @@ pub fn find_path(
     path
 }
 
+/// Vanilla `EnderDragon` sub entities, in `subEntities`: name, width, height.
+const PART_DIMENSIONS: [(&str, f32, f32); 8] = [
+    ("head", 1.0, 1.0),
+    ("neck", 3.0, 3.0),
+    ("body", 5.0, 3.0),
+    ("tail", 2.0, 2.0),
+    ("tail", 2.0, 2.0),
+    ("tail", 2.0, 2.0),
+    ("wing", 4.0, 2.0),
+    ("wing", 4.0, 2.0),
+];
+
+/// Only the head takes undivided damage.
+pub const PART_HEAD: usize = 0;
+/// Direct hits on the dragon count as body hits.
+pub const PART_BODY: usize = 2;
+
 pub struct EnderDragonPart {
     pub entity: Entity,
     pub dragon_uuid: uuid::Uuid,
+    pub index: usize,
+    pub name: &'static str,
 }
 
 impl EnderDragonPart {
-    pub const fn new(entity: Entity, dragon_uuid: uuid::Uuid) -> Self {
+    pub const fn new(
+        entity: Entity,
+        dragon_uuid: uuid::Uuid,
+        index: usize,
+        name: &'static str,
+    ) -> Self {
         Self {
             entity,
             dragon_uuid,
+            index,
+            name,
         }
     }
 }
@@ -160,17 +188,31 @@ impl EntityBase for EnderDragonPart {
         &self.entity
     }
 
-    fn damage(&self, source: &dyn EntityBase, amount: f32, damage_type: DamageType) -> bool {
+    fn damage_with_context(
+        &self,
+        _caller: &dyn EntityBase,
+        amount: f32,
+        damage_type: DamageType,
+        position: Option<Vector3<f64>>,
+        source: Option<&dyn EntityBase>,
+        cause: Option<&dyn EntityBase>,
+    ) -> bool {
         let world = self.entity.world.load();
-        if let Some(dragon_base) = world
-            .entities
-            .load()
-            .iter()
-            .find(|e| e.get_entity().entity_uuid == self.dragon_uuid)
-        {
-            return dragon_base.damage(source, amount, damage_type);
-        }
-        false
+        let Some(dragon) = world.get_entity_by_uuid(self.dragon_uuid) else {
+            return false;
+        };
+        let Some(dragon_entity) = dragon.cast_any().downcast_ref::<EnderDragonEntity>() else {
+            return false;
+        };
+        dragon_entity.hurt_part(
+            dragon.as_ref(),
+            self.index,
+            amount,
+            damage_type,
+            position,
+            source,
+            cause,
+        )
     }
 
     fn cast_any(&self) -> &dyn std::any::Any {
@@ -227,20 +269,32 @@ impl EnderDragonEntity {
         let dragon_uuid = entity.entity_uuid;
         let world = entity.world.load();
 
-        let _ = Entity::reserve_ids(8);
+        Entity::reserve_ids_after(base_id, PART_DIMENSIONS.len() as i32);
 
         let mut parts = Vec::new();
-        for i in 1..=8 {
+        for (i, (name, width, height)) in PART_DIMENSIONS.iter().enumerate() {
             let part_entity = Entity::from_uuid_with_id(
-                base_id + i,
+                base_id + i as i32 + 1,
                 uuid::Uuid::new_v4(),
                 world.clone(),
                 entity.pos.load(),
                 &EntityType::ENDER_DRAGON,
             );
-            let part = Arc::new(EnderDragonPart::new(part_entity, dragon_uuid));
-            // TODO: world.add_entity_silent(part.clone() as Arc<dyn EntityBase>);
-            parts.push(part);
+            let dimensions = EntityDimensions::new(*width, *height, *height);
+            part_entity.entity_dimension.store(dimensions);
+            let part_pos = part_entity.pos.load();
+            part_entity.bounding_box.store(BoundingBox::new_from_pos(
+                part_pos.x,
+                part_pos.y,
+                part_pos.z,
+                &dimensions,
+            ));
+            parts.push(Arc::new(EnderDragonPart::new(
+                part_entity,
+                dragon_uuid,
+                i,
+                name,
+            )));
         }
 
         Arc::new(Self {
@@ -831,17 +885,63 @@ impl EnderDragonEntity {
         self.tick_parts();
     }
 
-    pub fn hurt(&self, damage: f32) {
+    /// Vanilla `EnderDragon.hurt(level, part, source, damage)`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn hurt_part(
+        &self,
+        caller: &dyn EntityBase,
+        part: usize,
+        amount: f32,
+        damage_type: DamageType,
+        position: Option<Vector3<f64>>,
+        source: Option<&dyn EntityBase>,
+        cause: Option<&dyn EntityBase>,
+    ) -> bool {
         let phase_type: EnderDragonPhase = *self
             .phase
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if phase_type == EnderDragonPhase::Dying {
+            return false;
+        }
+
+        let amount = if part == PART_HEAD {
+            amount
+        } else {
+            amount / 4.0 + amount.min(1.0)
+        };
+        if amount < 0.01 {
+            return false;
+        }
+
+        let by_player = source.or(cause).is_some_and(|e| e.get_player().is_some());
+        if !by_player
+            && !damage_type.has_tag(&tag::DamageType::MINECRAFT_ALWAYS_HURTS_ENDER_DRAGONS)
+        {
+            return true;
+        }
+
+        let living = &self.mob_entity.living_entity;
+        let health_before = living.health.load();
+        // bypasses the dragon's own `hurtServer`.
+        if living.damage_with_context(caller, amount, damage_type, position, source, cause) {
+            self.on_damage(damage_type, source);
+        }
+
         if phase_type.is_sitting() {
-            *self
+            let mut received = self
                 .sitting_damage_received
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) += damage;
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *received += health_before - living.health.load();
+            if *received > 0.25 * living.get_max_health() {
+                *received = 0.0;
+                drop(received);
+                self.set_phase(EnderDragonPhase::TakingOff);
+            }
         }
+
+        true
     }
 }
 
@@ -859,6 +959,32 @@ impl Mob for EnderDragonEntity {
         if living.health.load() <= 0.0 {
             self.set_phase(EnderDragonPhase::Dying);
         }
+    }
+
+    /// a hit that does not name a part counts as a body hit.
+    fn mob_damage_with_context(
+        &self,
+        caller: &dyn EntityBase,
+        amount: f32,
+        damage_type: DamageType,
+        position: Option<Vector3<f64>>,
+        source: Option<&dyn EntityBase>,
+        cause: Option<&dyn EntityBase>,
+    ) -> bool {
+        self.hurt_part(
+            caller,
+            PART_BODY,
+            amount,
+            damage_type,
+            position,
+            source,
+            cause,
+        )
+    }
+
+    /// overrides `checkDespawn` to do nothing.
+    fn remove_when_far_away(&self, _distance_sq: f64) -> bool {
+        false
     }
 
     fn get_mob_gravity(&self) -> f64 {

--- a/crates/pumpkin/src/entity/boss/ender_dragon.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon.rs
@@ -238,6 +238,8 @@ pub struct EnderDragonEntity {
     pub in_wall: Mutex<bool>,
     pub dragon_death_time: Mutex<i32>,
     pub sitting_damage_received: Mutex<f32>,
+    /// Crystal currently healing the dragon
+    pub nearest_crystal: Mutex<Option<uuid::Uuid>>,
 
     pub nodes_initialized: Mutex<bool>,
 
@@ -305,6 +307,7 @@ impl EnderDragonEntity {
             in_wall: Mutex::new(false),
             dragon_death_time: Mutex::new(0),
             sitting_damage_received: Mutex::new(0.0),
+            nearest_crystal: Mutex::new(None),
             nodes_initialized: Mutex::new(false),
             fight_origin: Mutex::new(BlockPos::new(0, 128, 0)),
             phase_manager: PhaseManager::new(),
@@ -671,29 +674,47 @@ impl EnderDragonEntity {
         }
     }
 
-    fn tick_crystal_healing(&self) {
-        let world = self.mob_entity.living_entity.entity.world.load();
-        let pos = self.mob_entity.living_entity.entity.pos.load();
+    /// Vanilla `EnderDragon.checkCrystals`. The client picks the beam's crystal the
+    /// same way, so the beam itself needs no packet.
+    fn check_crystals(&self) {
+        let entity = &self.mob_entity.living_entity.entity;
+        let world = entity.world.load();
+        let mut nearest = self
+            .nearest_crystal
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        let mut nearest_crystal = None;
-        let mut min_dist_sq = 1024.0; // 32 blocks
-
-        for entity in world.entities.load().iter() {
-            if entity.get_entity().entity_type == &EntityType::END_CRYSTAL {
-                let crystal_pos = entity.get_entity().pos.load();
-                let dist_sq = pos.distance_squared(crystal_pos);
-                if dist_sq < min_dist_sq {
-                    min_dist_sq = dist_sq;
-                    nearest_crystal = Some(entity.clone());
+        if let Some(uuid) = *nearest {
+            let alive = world
+                .get_entity_by_uuid(uuid)
+                .is_some_and(|crystal| !crystal.get_entity().is_removed());
+            if alive {
+                let living = &self.mob_entity.living_entity;
+                if entity.age.load(Ordering::Relaxed) % 10 == 0
+                    && living.health.load() < living.get_max_health()
+                {
+                    living.heal(1.0);
                 }
+            } else {
+                *nearest = None;
             }
         }
 
-        if let Some(_crystal) = nearest_crystal {
-            let living = &self.mob_entity.living_entity;
-            if living.health.load() < living.get_max_health() {
-                living.heal(1.0);
-            }
+        if rand::random_range(0..10) == 0 {
+            let pos = entity.pos.load();
+            let search = entity.bounding_box.load().expand_all(32.0);
+            *nearest = world
+                .get_entities_at_box(&search)
+                .into_iter()
+                .filter(|e| e.get_entity().entity_type == &EntityType::END_CRYSTAL)
+                .min_by(|a, b| {
+                    a.get_entity()
+                        .pos
+                        .load()
+                        .distance_squared(pos)
+                        .total_cmp(&b.get_entity().pos.load().distance_squared(pos))
+                })
+                .map(|e| e.get_entity().entity_uuid);
         }
     }
 
@@ -829,7 +850,7 @@ impl EnderDragonEntity {
         };
 
         self.tick_growl();
-        self.tick_crystal_healing();
+        self.check_crystals();
 
         {
             let world = self.mob_entity.living_entity.entity.world.load();

--- a/crates/pumpkin/src/entity/boss/ender_dragon.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon.rs
@@ -144,7 +144,7 @@ pub fn find_path(
 }
 
 /// Vanilla `EnderDragon` sub entities, in `subEntities`: name, width, height.
-const PART_DIMENSIONS: [(&str, f32, f32); 8] = [
+pub const PART_DIMENSIONS: [(&str, f32, f32); 8] = [
     ("head", 1.0, 1.0),
     ("neck", 3.0, 3.0),
     ("body", 5.0, 3.0),
@@ -269,8 +269,7 @@ impl EnderDragonEntity {
         let dragon_uuid = entity.entity_uuid;
         let world = entity.world.load();
 
-        Entity::reserve_ids_after(base_id, PART_DIMENSIONS.len() as i32);
-
+        // The part ids follow the dragon's, `from_type` reserved them with it.
         let mut parts = Vec::new();
         for (i, (name, width, height)) in PART_DIMENSIONS.iter().enumerate() {
             let part_entity = Entity::from_uuid_with_id(

--- a/crates/pumpkin/src/entity/boss/ender_dragon.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon.rs
@@ -756,10 +756,6 @@ impl EnderDragonEntity {
                 pos.z + (cc1 * 1.5 + cc * dd) * cc_tilt,
             ));
         }
-
-        for part in &self.parts {
-            part.entity.send_pos_rot();
-        }
     }
 
     pub fn ai_step(&self) {
@@ -832,7 +828,6 @@ impl EnderDragonEntity {
             }
         }
 
-        self.mob_entity.living_entity.entity.send_pos_rot();
         self.tick_parts();
     }
 

--- a/crates/pumpkin/src/entity/boss/ender_dragon/phase/mod.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon/phase/mod.rs
@@ -63,14 +63,11 @@ pub enum EnderDragonPhase {
 
 impl EnderDragonPhase {
     #[must_use]
+    /// the sitting phases plus `DragonHoverPhase`.
     pub const fn is_sitting(self) -> bool {
         matches!(
             self,
-            Self::LandingApproach
-                | Self::Landing
-                | Self::SitAttacking
-                | Self::SitBreathing
-                | Self::TakingOff
+            Self::SitAttacking | Self::SitBreathing | Self::Hovering
         )
     }
 

--- a/crates/pumpkin/src/entity/boss/ender_dragon/phase/sit_attacking.rs
+++ b/crates/pumpkin/src/entity/boss/ender_dragon/phase/sit_attacking.rs
@@ -41,18 +41,6 @@ impl super::Phase for SitAttackingPhase {
             } else if should_take_off {
                 dragon.set_phase(EnderDragonPhase::TakingOff);
             }
-        } else {
-            drop(timer);
-        }
-
-        let mut dmg = dragon
-            .sitting_damage_received
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if *dmg > 150.0 {
-            *dmg = 0.0;
-            drop(dmg);
-            dragon.set_phase(EnderDragonPhase::TakingOff);
         }
     }
 }

--- a/crates/pumpkin/src/entity/falling.rs
+++ b/crates/pumpkin/src/entity/falling.rs
@@ -1,8 +1,11 @@
 use pumpkin_data::Block;
+use pumpkin_data::BlockState;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::tag::{self, Taggable};
+use pumpkin_protocol::bedrock::client::CUpdateBlock;
+use pumpkin_protocol::java::client::play::CBlockUpdate;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
 use std::sync::{Arc, atomic::Ordering};
@@ -70,15 +73,17 @@ impl EntityBase for FallingEntity {
                 state_id = concrete.default_state.id;
             }
             world.set_block_state(&landing_pos, state_id, BlockFlags::NOTIFY_ALL);
+            // block updates to watchers before the despawn, else a invisible block gap until the tick flush.
+            let placed = world.get_block_state_id(&landing_pos);
+            world.send_to_tracking_players_editioned(
+                entity,
+                &CBlockUpdate::new(landing_pos, i32::from(placed.as_u16()).into()),
+                &CUpdateBlock::new(landing_pos, BlockState::to_be_network_id(placed) as u32),
+            );
             self.entity.remove();
         }
 
         entity.velocity.store(velo.multiply(0.98, 0.98, 0.98));
-
-        if entity.velocity_dirty.swap(false, Ordering::SeqCst) {
-            entity.send_pos_rot();
-            entity.send_velocity();
-        }
     }
 
     fn init_data_tracker(&self) {
@@ -101,6 +106,11 @@ impl EntityBase for FallingEntity {
 
     fn get_gravity(&self) -> f64 {
         0.04
+    }
+
+    // TODO: Bedrock spawn metadata lacks the block variant (renders grey while falling)
+    fn bedrock_y_offset(&self) -> f64 {
+        0.49
     }
 
     fn cast_any(&self) -> &dyn std::any::Any {

--- a/crates/pumpkin/src/entity/item.rs
+++ b/crates/pumpkin/src/entity/item.rs
@@ -79,8 +79,6 @@ impl Drop for ItemMergeReservation<'_> {
     }
 }
 
-const ITEM_UPDATE_INTERVAL: u32 = 20;
-
 impl ItemEntity {
     pub fn new(entity: Entity, item_stack: ItemStack) -> Self {
         entity.velocity.store(Vector3::new(
@@ -505,29 +503,17 @@ impl ItemEntity {
         true
     }
 
-    fn sync_motion_if_dirty(&self, caller: &dyn EntityBase, original_velo: Vector3<f64>) {
+    /// Vanilla `ItemEntity.tick` `needsSync`: fluid contact or velocity change.
+    fn mark_needs_sync(&self, caller: &dyn EntityBase, original_velo: Vector3<f64>) {
         let entity = &self.entity;
 
         entity.update_fluid_state(caller);
 
-        let velocity_dirty = entity.velocity_dirty.swap(false, Ordering::SeqCst)
-            || entity.touching_water.load(Ordering::SeqCst)
+        if entity.touching_water.load(Ordering::SeqCst)
             || entity.touching_lava.load(Ordering::SeqCst)
-            || entity.velocity.load().sub(&original_velo).length_squared() > 0.1;
-        let moved = entity.pos.load() != entity.last_sent_pos.load();
-        let position_dirty = moved
-            && self
-                .item_age
-                .load(Ordering::Relaxed)
-                .is_multiple_of(ITEM_UPDATE_INTERVAL);
-
-        if position_dirty || velocity_dirty {
-            entity.send_pos_rot();
-        } else if moved {
-            entity.send_bedrock_pos();
-        }
-        if velocity_dirty {
-            entity.send_velocity();
+            || entity.velocity.load().sub(&original_velo).length_squared() > 0.01
+        {
+            entity.velocity_dirty.store(true, Ordering::SeqCst);
         }
     }
 }
@@ -555,7 +541,7 @@ impl EntityBase for ItemEntity {
         }
 
         if self.process_age_and_merge() {
-            self.sync_motion_if_dirty(caller, original_velo);
+            self.mark_needs_sync(caller, original_velo);
         }
     }
 
@@ -686,6 +672,10 @@ impl EntityBase for ItemEntity {
         0.04
     }
 
+    fn bedrock_y_offset(&self) -> f64 {
+        0.125
+    }
+
     fn write_custom_nbt(&self, nbt: &mut NbtCompound) {
         let item = self
             .item_stack
@@ -745,7 +735,7 @@ impl EntityBase for ItemEntity {
                 target_actor_id: VarLong(runtime_id as i64),
                 target_runtime_id: VarULong(runtime_id),
                 item: ItemStackWrapper::from(&*item_stack),
-                position: entity.pos.load().to_f32_lossy(),
+                position: self.bedrock_pos().to_f32_lossy(),
                 velocity: entity.velocity.load().to_f32_lossy(),
                 entity_data: entity.bedrock_metadata(),
                 is_from_fishing: false,

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3139,14 +3139,6 @@ impl EntityBase for LivingEntity {
             self.entity.send_velocity();
         }
 
-        // TODO
-        let player = caller.get_player();
-        let is_player = player.is_some();
-
-        if !is_player {
-            self.entity.send_pos_rot();
-        }
-
         // Fetch supporting blocks for players or other entities
         let supporting_pos = caller.get_player().map_or_else(
             || self.entity.get_supporting_block_pos(),

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -744,6 +744,36 @@ pub trait Mob: EntityBase + Send + Sync {
         amount
     }
 
+    /// Whole damage path, so a mob can replace it (vanilla `hurtServer` override).
+    fn mob_damage_with_context(
+        &self,
+        caller: &dyn EntityBase,
+        amount: f32,
+        damage_type: DamageType,
+        position: Option<Vector3<f64>>,
+        source: Option<&dyn EntityBase>,
+        cause: Option<&dyn EntityBase>,
+    ) -> bool {
+        // pre_damage, allows mobs to dodge/cancel damage
+        if !self.pre_damage(damage_type, source) {
+            return false;
+        }
+        // Mob-specific damage modifier
+        let amount = self.modify_incoming_damage(amount, damage_type);
+        let damaged = self.get_mob_entity().living_entity.damage_with_context(
+            caller,
+            amount,
+            damage_type,
+            position,
+            source,
+            cause,
+        );
+        if damaged {
+            self.on_damage(damage_type, source);
+        }
+        damaged
+    }
+
     fn can_attack_with_owner(&self, _target: &dyn EntityBase, _owner: &dyn EntityBase) -> bool {
         true
     }
@@ -1226,24 +1256,7 @@ impl<T: Mob + Send + 'static> EntityBase for T {
         source: Option<&dyn EntityBase>,
         cause: Option<&dyn EntityBase>,
     ) -> bool {
-        // pre_damage hook: allows mobs to dodge/cancel damage (e.g. enderman projectile dodge)
-        if !self.pre_damage(damage_type, source) {
-            return false;
-        }
-        // Mob-specific damage modifier (e.g. shulker armor when closed).
-        let amount = self.modify_incoming_damage(amount, damage_type);
-        let damaged = self.get_mob_entity().living_entity.damage_with_context(
-            caller,
-            amount,
-            damage_type,
-            position,
-            source,
-            cause,
-        );
-        if damaged {
-            self.on_damage(damage_type, source);
-        }
-        damaged
+        self.mob_damage_with_context(caller, amount, damage_type, position, source, cause)
     }
 
     fn interact(&self, player: &Arc<Player>, item_stack: &mut ItemStack) -> bool {

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -16,7 +16,6 @@ use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data;
 use pumpkin_data::{Block, BlockDirection};
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::java::client::play::{CHeadRot, CUpdateEntityRot};
 use pumpkin_util::Difficulty;
 use pumpkin_util::math::boundingbox::BoundingBox;
 use pumpkin_util::math::position::BlockPos;
@@ -85,9 +84,6 @@ pub struct MobEntity {
     pub breeder: AtomicCell<Option<Uuid>>,
     pub persistence_required: AtomicBool,
     mob_flags: AtomicU8,
-    last_sent_yaw: AtomicU8,
-    last_sent_pitch: AtomicU8,
-    last_sent_head_yaw: AtomicU8,
 }
 impl MobEntity {
     const AI_DISABLED_FLAG: u8 = 1;
@@ -171,9 +167,6 @@ impl MobEntity {
             breeder: AtomicCell::new(None),
             persistence_required: AtomicBool::new(false),
             mob_flags: AtomicU8::new(0),
-            last_sent_yaw: AtomicU8::new(0),
-            last_sent_pitch: AtomicU8::new(0),
-            last_sent_head_yaw: AtomicU8::new(0),
         }
     }
 
@@ -1214,39 +1207,6 @@ impl<T: Mob + Send + 'static> EntityBase for T {
 
         mob_entity.living_entity.tick(caller, server);
         self.post_tick();
-
-        // --- Packet logic remains the same ---
-        let entity = &mob_entity.living_entity.entity;
-        let yaw = (entity.yaw.load() * 256.0 / 360.0).rem_euclid(256.0) as u8;
-        let pitch = (entity.pitch.load() * 256.0 / 360.0).rem_euclid(256.0) as u8;
-        let head_yaw = (entity.head_yaw.load() * 256.0 / 360.0).rem_euclid(256.0) as u8;
-
-        let last_yaw = mob_entity.last_sent_yaw.load(Relaxed);
-        let last_pitch = mob_entity.last_sent_pitch.load(Relaxed);
-        let last_head_yaw = mob_entity.last_sent_head_yaw.load(Relaxed);
-
-        let chunk_pos = entity.chunk_pos.load();
-        if yaw.abs_diff(last_yaw) >= 1 || pitch.abs_diff(last_pitch) >= 1 {
-            let world = entity.world.load();
-            world.broadcast_to_chunk(
-                chunk_pos,
-                &CUpdateEntityRot::new(
-                    entity.entity_id.into(),
-                    yaw,
-                    pitch,
-                    entity.on_ground.load(Relaxed),
-                ),
-            );
-            mob_entity.last_sent_yaw.store(yaw, Relaxed);
-            mob_entity.last_sent_pitch.store(pitch, Relaxed);
-        }
-
-        if head_yaw.abs_diff(last_head_yaw) >= 1 {
-            let world = entity.world.load();
-
-            world.broadcast_to_chunk(chunk_pos, &CHeadRot::new(entity.entity_id.into(), head_yaw));
-            mob_entity.last_sent_head_yaw.store(head_yaw, Relaxed);
-        }
     }
 
     fn is_collidable(&self, _entity: Option<Box<dyn EntityBase>>) -> bool {

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -892,7 +892,7 @@ pub struct Entity {
     pub synched_data: synched_entity_data::SynchedEntityData,
     /// Multiplies movement for one tick before being reset
     pub movement_multiplier: AtomicCell<Vector3<f64>>,
-    /// Vanilla `needsSync`: tracker resyncs position and velocity of enteties
+    /// Vanilla `needsSync`: tracker resyncs position and velocity of entities
     pub velocity_dirty: AtomicBool,
     /// Set when an Entity is to be removed but could still be referenced
     pub removed: AtomicBool,

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -634,7 +634,8 @@ pub trait EntityBase: Send + Sync + std::any::Any {
         } else {
             let other_entities = world.get_entities_at_box(&entity_bb);
             for other in other_entities {
-                if other.get_entity().entity_id != self_entity.entity_id {
+                // Vanilla `pushableBy` skips unpushable entities, dragon parts among them.
+                if other.get_entity().entity_id != self_entity.entity_id && other.is_pushable() {
                     dyn_self.push(other.as_ref());
                     pushed = true;
                 }
@@ -921,8 +922,10 @@ impl Entity {
         Self::from_uuid(Uuid::new_v4(), world, position, entity_type)
     }
 
-    pub fn reserve_ids(count: i32) -> i32 {
-        CURRENT_ID.fetch_add(count, Relaxed)
+    /// Claims the `count` ids right after `after`, if they are still free.
+    /// Dragon parts must keep these ids, the client derives them from the dragon's.
+    pub fn reserve_ids_after(after: i32, count: i32) {
+        let _ = CURRENT_ID.compare_exchange(after + 1, after + 1 + count, Relaxed, Relaxed);
     }
 
     pub fn from_uuid(

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -922,10 +922,9 @@ impl Entity {
         Self::from_uuid(Uuid::new_v4(), world, position, entity_type)
     }
 
-    /// Claims the `count` ids right after `after`, if they are still free.
-    /// Dragon parts must keep these ids, the client derives them from the dragon's.
-    pub fn reserve_ids_after(after: i32, count: i32) {
-        let _ = CURRENT_ID.compare_exchange(after + 1, after + 1 + count, Relaxed, Relaxed);
+    /// Reserves `count` consecutive ids and returns the first.
+    pub fn reserve_ids(count: i32) -> i32 {
+        CURRENT_ID.fetch_add(count, Relaxed)
     }
 
     pub fn from_uuid(

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2736,6 +2736,9 @@ impl Entity {
         let mut bedrock_recipients = Vec::new();
 
         if let Some(tracked) = world.entity_tracker.get_tracked_entity(self.entity_id) {
+            if !tracked.has_bedrock_watchers() && self.entity_type != &EntityType::PLAYER {
+                return;
+            }
             for player in players.iter() {
                 if (tracked.seen_by.contains(&player.gameprofile.id)
                     || player.entity_id() == self.entity_id)
@@ -2785,6 +2788,10 @@ impl Entity {
         let mut java_recipients = Vec::new();
 
         if let Some(tracked) = world.entity_tracker.get_tracked_entity(self.entity_id) {
+            if tracked.seen_by.is_empty() && self.entity_type != &EntityType::PLAYER {
+                self.synched_data.clear_dirty();
+                return;
+            }
             for player in players.iter() {
                 if (tracked.seen_by.contains(&player.gameprofile.id)
                     || player.entity_id() == self.entity_id)

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2808,6 +2808,8 @@ impl Entity {
         }
 
         if java_recipients.is_empty() {
+            // Vanilla `packDirty` clears even without recipients.
+            self.synched_data.clear_dirty();
             return;
         }
 

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -33,28 +33,17 @@ use pumpkin_data::{
 use pumpkin_nbt::{compound::NbtCompound, tag::NbtTag};
 use pumpkin_protocol::bedrock::client::{CAddActor, CSetActorMotion};
 use pumpkin_protocol::codec::var_long::VarLong;
-use pumpkin_protocol::java::client::play::{CUpdateEntityPos, CUpdateEntityPosRot};
 use pumpkin_protocol::{
     PositionFlag,
-    bedrock::client::{
-        move_actor_delta::{
-            CMoveActorDelta, MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW, MOVE_ACTOR_DELTA_FLAG_HAS_PITCH,
-            MOVE_ACTOR_DELTA_FLAG_HAS_X, MOVE_ACTOR_DELTA_FLAG_HAS_Y,
-            MOVE_ACTOR_DELTA_FLAG_HAS_YAW, MOVE_ACTOR_DELTA_FLAG_HAS_Z,
-            MOVE_ACTOR_DELTA_FLAG_ON_GROUND,
-        },
-        move_player::CMovePlayer,
-        set_actor_data::{
-            CSetActorData, MetadataValue, PropertySyncData, SyncedActorDataList, entity_data_flag,
-            entity_data_key,
-        },
+    bedrock::client::set_actor_data::{
+        CSetActorData, MetadataValue, PropertySyncData, SyncedActorDataList, entity_data_flag,
+        entity_data_key,
     },
     codec::var_int::VarInt,
     codec::var_ulong::VarULong,
     java::client::play::{
-        CEntityPositionSync, CEntityVelocity, CHeadRot, CPlayerPosition, CSetEntityMetadata,
-        CSetPassengers, CSpawnEntity, CSpawnLivingEntity, CUpdateEntityRot, Metadata,
-        MetadataSerializer,
+        CEntityPositionSync, CEntityVelocity, CPlayerPosition, CSetEntityMetadata, CSetPassengers,
+        CSpawnEntity, CSpawnLivingEntity, Metadata, MetadataSerializer,
     },
 };
 use pumpkin_util::math::vector3::Axis;
@@ -235,6 +224,18 @@ pub trait EntityBase: Send + Sync + std::any::Any {
         0.0
     }
 
+    /// Bedrock network Y above the feet. Endstone `getBaseOffset`.
+    fn bedrock_y_offset(&self) -> f64 {
+        0.0
+    }
+
+    fn bedrock_pos(&self) -> Vector3<f64> {
+        self.get_entity()
+            .pos
+            .load()
+            .add_raw(0.0, self.bedrock_y_offset(), 0.0)
+    }
+
     fn get_mob(&self) -> Option<&dyn mob::Mob> {
         None
     }
@@ -339,6 +340,7 @@ pub trait EntityBase: Send + Sync + std::any::Any {
             .get_mob()
             .and_then(mob::Mob::mob_bedrock_identifier)
             .unwrap_or(entity.entity_type.resource_name);
+        // TODO: non-mob spawn metadata hook like `mob_bedrock_spawn_metadata` (falling block, TNT).
         let mut metadata = entity.bedrock_metadata();
         if let Some(mob) = self.get_mob()
             && let Some(mob_metadata) = mob.mob_bedrock_spawn_metadata()
@@ -349,7 +351,7 @@ pub trait EntityBase: Send + Sync + std::any::Any {
             target_actor_id: VarLong(runtime_id as i64),
             target_runtime_id: VarULong(runtime_id),
             actor_type: identifier.to_string(),
-            position: entity.pos.load().to_f32_lossy(),
+            position: self.bedrock_pos().to_f32_lossy(),
             velocity: entity.velocity.load().to_f32_lossy(),
             rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
             y_head_rotation: entity.head_yaw.load(),
@@ -890,7 +892,7 @@ pub struct Entity {
     pub synched_data: synched_entity_data::SynchedEntityData,
     /// Multiplies movement for one tick before being reset
     pub movement_multiplier: AtomicCell<Vector3<f64>>,
-    /// Determines whether the entity's velocity needs to be sent
+    /// Vanilla `needsSync`: tracker resyncs position and velocity of enteties
     pub velocity_dirty: AtomicBool,
     /// Set when an Entity is to be removed but could still be referenced
     pub removed: AtomicBool,
@@ -898,11 +900,13 @@ pub struct Entity {
     pub last_sent_yaw: AtomicU8,
     /// The last sent pitch value (encoded as u8) for change detection
     pub last_sent_pitch: AtomicU8,
-    /// Cache for the last sent position to optimize Entity Pos update packets
+    /// Delta base of the move packets. Vanilla `ServerEntity.positionCodec`.
     pub last_sent_pos: AtomicCell<Vector3<f64>>,
     /// Cache for the last sent head yaw byte
     pub last_sent_head_yaw: AtomicU8,
-    /// Persistent custom data container for plugins (matching Bukkit's `PersistentDataHolder`)
+    /// Velocity last put on the wire. Vanilla `ServerEntity.lastSentMovement`.
+    pub last_sent_velocity: AtomicCell<Vector3<f64>>,
+    /// Persistent custom data container for plugins
     pub custom_data: std::sync::Mutex<NbtCompound>,
 }
 
@@ -1031,6 +1035,7 @@ impl Entity {
             last_sent_pitch: AtomicU8::new(0),
             last_sent_head_yaw: AtomicU8::new(0),
             last_sent_pos: AtomicCell::new(position),
+            last_sent_velocity: AtomicCell::new(Vector3::default()),
             custom_data: std::sync::Mutex::new(NbtCompound::new()),
         }
     }
@@ -1198,18 +1203,21 @@ impl Entity {
         self.set_synced_data(tracked_data::entity::DATA_NO_GRAVITY, no_gravity);
     }
 
+    /// Vanilla `hurtMarked` path: immediate, to watchers and self.
     pub fn send_velocity(&self) {
         let velocity = self.velocity.load();
-        let chunk_pos = self.chunk_pos.load();
-        self.world.load().broadcast_to_chunk_editioned(
-            chunk_pos,
-            &CEntityVelocity::new(self.entity_id.into(), velocity),
-            &CSetActorMotion {
-                target_runtime_id: VarULong(self.entity_id as u64),
-                motion: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-                tick: VarULong(0),
-            },
-        );
+        self.last_sent_velocity.store(velocity);
+        self.world
+            .load()
+            .send_to_tracking_players_and_self_editioned(
+                self,
+                &CEntityVelocity::new(self.entity_id.into(), velocity),
+                &CSetActorMotion {
+                    target_runtime_id: VarULong(self.entity_id as u64),
+                    motion: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
+                    tick: VarULong(0),
+                },
+            );
     }
 
     #[must_use]
@@ -1297,48 +1305,6 @@ impl Entity {
         let yaw = wrap_degrees((delta.z.atan2(delta.x) as f32).to_degrees() - 90.0);
         self.pitch.store(pitch);
         self.yaw.store(yaw);
-    }
-
-    pub fn send_rotation(&self) {
-        let yaw = self.yaw.load();
-        let pitch = self.pitch.load();
-        let chunk_pos = self.chunk_pos.load();
-
-        // Broadcast the update packet.
-
-        let yaw = (yaw * 256.0 / 360.0).rem_euclid(256.0) as u8;
-        let pitch = (pitch * 256.0 / 360.0).rem_euclid(256.0) as u8;
-
-        if yaw == self.last_sent_yaw.load(Relaxed) && pitch == self.last_sent_pitch.load(Relaxed) {
-            return;
-        }
-
-        self.last_sent_yaw.store(yaw, Relaxed);
-        self.last_sent_pitch.store(pitch, Relaxed);
-
-        self.world.load().broadcast_to_chunk(
-            chunk_pos,
-            &CUpdateEntityRot::new(
-                self.entity_id.into(),
-                yaw,
-                pitch,
-                self.on_ground.load(Relaxed),
-            ),
-        );
-
-        self.send_head_rot(yaw);
-    }
-
-    pub fn send_head_rot(&self, head_yaw: u8) {
-        let chunk_pos = self.chunk_pos.load();
-        if head_yaw == self.last_sent_head_yaw.load(Relaxed) {
-            return;
-        }
-        self.last_sent_head_yaw.store(head_yaw, Relaxed);
-
-        self.world
-            .load()
-            .broadcast_to_chunk(chunk_pos, &CHeadRot::new(self.entity_id.into(), head_yaw));
     }
 
     fn default_portal_cooldown(&self) -> u32 {
@@ -1669,282 +1635,12 @@ impl Entity {
         suffocating
     }
 
-    #[expect(clippy::too_many_lines)]
-    pub fn send_pos_rot(&self) {
-        let old = self.last_sent_pos.load();
-        let new = self.pos.load();
-        let chunk_pos = self.chunk_pos.load();
-
-        let converted = Vector3::new(
-            new.x.mul_add(4096.0, -(old.x * 4096.0)) as i16,
-            new.y.mul_add(4096.0, -(old.y * 4096.0)) as i16,
-            new.z.mul_add(4096.0, -(old.z * 4096.0)) as i16,
-        );
-
-        let yaw = self.yaw.load();
-
-        let pitch = self.pitch.load();
-        let yaw = (yaw * 256.0 / 360.0).rem_euclid(256.0) as u8;
-        let pitch = (pitch * 256.0 / 360.0).rem_euclid(256.0) as u8;
-
-        // Only broadcast when position or rotation has actually changed.
-        let pos_changed = converted.x != 0 || converted.y != 0 || converted.z != 0;
-        let rot_changed =
-            yaw != self.last_sent_yaw.load(Relaxed) || pitch != self.last_sent_pitch.load(Relaxed);
-
-        if !pos_changed && !rot_changed {
-            return;
-        }
-
-        self.last_sent_pos.store(new);
-        self.last_sent_yaw.store(yaw, Relaxed);
-        self.last_sent_pitch.store(pitch, Relaxed);
-
-        // Dynamically pick the most efficient packet
-        if pos_changed && rot_changed {
-            let je_packet = CUpdateEntityPosRot::new(
-                self.entity_id.into(),
-                Vector3::new(converted.x, converted.y, converted.z),
-                yaw,
-                pitch,
-                self.on_ground.load(Relaxed),
-            );
-            if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMovePlayer::new(
-                        VarULong(self.entity_id as u64),
-                        Vector3::new(new.x as f32, new.y as f32, new.z as f32),
-                        self.pitch.load(),
-                        self.yaw.load(),
-                        self.yaw.load(),
-                        CMovePlayer::MODE_NORMAL,
-                        self.on_ground.load(Relaxed),
-                        VarULong(0),
-                        0,
-                        0,
-                        VarULong(0),
-                    ),
-                );
-            } else {
-                let mut flags = MOVE_ACTOR_DELTA_FLAG_HAS_X
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_Y
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_Z
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_PITCH
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_YAW
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW;
-                if self.on_ground.load(Relaxed) {
-                    flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
-                }
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMoveActorDelta::new(
-                        VarULong(self.entity_id as u64),
-                        flags,
-                        new.x as f32,
-                        new.y as f32,
-                        new.z as f32,
-                        pitch,
-                        yaw,
-                        yaw,
-                    ),
-                );
-            }
-        } else if pos_changed {
-            let je_packet = CUpdateEntityPos::new(
-                self.entity_id.into(),
-                Vector3::new(converted.x, converted.y, converted.z),
-                self.on_ground.load(Relaxed),
-            );
-            if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMovePlayer::new(
-                        VarULong(self.entity_id as u64),
-                        Vector3::new(new.x as f32, new.y as f32, new.z as f32),
-                        self.pitch.load(),
-                        self.yaw.load(),
-                        self.yaw.load(),
-                        CMovePlayer::MODE_NORMAL,
-                        self.on_ground.load(Relaxed),
-                        VarULong(0),
-                        0,
-                        0,
-                        VarULong(0),
-                    ),
-                );
-            } else {
-                let mut flags = MOVE_ACTOR_DELTA_FLAG_HAS_X
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_Y
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_Z;
-                if self.on_ground.load(Relaxed) {
-                    flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
-                }
-
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMoveActorDelta::new(
-                        VarULong(self.entity_id as u64),
-                        flags,
-                        new.x as f32,
-                        new.y as f32,
-                        new.z as f32,
-                        0,
-                        0,
-                        0,
-                    ),
-                );
-            }
-        } else if rot_changed {
-            let je_packet = CUpdateEntityRot::new(
-                self.entity_id.into(),
-                yaw,
-                pitch,
-                self.on_ground.load(Relaxed),
-            );
-            if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMovePlayer::new(
-                        VarULong(self.entity_id as u64),
-                        Vector3::new(new.x as f32, new.y as f32, new.z as f32),
-                        self.pitch.load(),
-                        self.yaw.load(),
-                        self.yaw.load(),
-                        CMovePlayer::MODE_ROTATION,
-                        self.on_ground.load(Relaxed),
-                        VarULong(0),
-                        0,
-                        0,
-                        VarULong(0),
-                    ),
-                );
-            } else {
-                let mut flags = MOVE_ACTOR_DELTA_FLAG_HAS_PITCH
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_YAW
-                    | MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW;
-                if self.on_ground.load(Relaxed) {
-                    flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
-                }
-                self.world.load().broadcast_to_chunk_editioned(
-                    chunk_pos,
-                    &je_packet,
-                    &CMoveActorDelta::new(
-                        VarULong(self.entity_id as u64),
-                        flags,
-                        new.x as f32,
-                        new.y as f32,
-                        new.z as f32,
-                        pitch,
-                        yaw,
-                        yaw,
-                    ),
-                );
-            }
-        }
-        self.send_head_rot(yaw);
-    }
-
-    pub fn send_bedrock_pos(&self) {
-        let position = self.pos.load();
-        let chunk_pos = self.chunk_pos.load();
-        let mut flags =
-            MOVE_ACTOR_DELTA_FLAG_HAS_X | MOVE_ACTOR_DELTA_FLAG_HAS_Y | MOVE_ACTOR_DELTA_FLAG_HAS_Z;
-        if self.on_ground.load(Relaxed) {
-            flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
-        }
-        let packet = CMoveActorDelta::new(
-            VarULong(self.entity_id as u64),
-            flags,
-            position.x as f32,
-            position.y as f32,
-            position.z as f32,
-            0,
-            0,
-            0,
-        );
-        let world = self.world.load();
-        world.broadcast_to_chunk_bedrock(chunk_pos, &packet);
-    }
-
     pub fn update_last_pos(&self) -> Vector3<f64> {
         let pos = self.pos.load();
         let old = self.last_pos.load();
         self.movement.store(pos - old);
         self.last_pos.store(pos);
         old
-    }
-
-    pub fn send_pos(&self) {
-        let old = self.last_sent_pos.load();
-        let new = self.pos.load();
-        let chunk_pos = self.chunk_pos.load();
-
-        let converted = Vector3::new(
-            new.x.mul_add(4096.0, -(old.x * 4096.0)) as i16,
-            new.y.mul_add(4096.0, -(old.y * 4096.0)) as i16,
-            new.z.mul_add(4096.0, -(old.z * 4096.0)) as i16,
-        );
-
-        // Only broadcast when position has actually changed.
-        if converted.x == 0 && converted.y == 0 && converted.z == 0 {
-            return;
-        }
-
-        self.last_sent_pos.store(new);
-
-        let je_packet = CUpdateEntityPos::new(
-            self.entity_id.into(),
-            Vector3::new(converted.x, converted.y, converted.z),
-            self.on_ground.load(Relaxed),
-        );
-
-        if self.entity_type == &EntityType::PLAYER {
-            self.world.load().broadcast_to_chunk_editioned(
-                chunk_pos,
-                &je_packet,
-                &CMovePlayer::new(
-                    VarULong(self.entity_id as u64),
-                    Vector3::new(new.x as f32, new.y as f32, new.z as f32),
-                    self.pitch.load(),
-                    self.yaw.load(),
-                    self.yaw.load(),
-                    CMovePlayer::MODE_NORMAL,
-                    self.on_ground.load(Relaxed),
-                    VarULong(0),
-                    0,
-                    0,
-                    VarULong(0),
-                ),
-            );
-        } else {
-            let mut flags = MOVE_ACTOR_DELTA_FLAG_HAS_X
-                | MOVE_ACTOR_DELTA_FLAG_HAS_Y
-                | MOVE_ACTOR_DELTA_FLAG_HAS_Z;
-            if self.on_ground.load(Relaxed) {
-                flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
-            }
-
-            self.world.load().broadcast_to_chunk_editioned(
-                chunk_pos,
-                &je_packet,
-                &CMoveActorDelta::new(
-                    VarULong(self.entity_id as u64),
-                    flags,
-                    new.x as f32,
-                    new.y as f32,
-                    new.z as f32,
-                    0,
-                    0,
-                    0,
-                ),
-            );
-        }
     }
 
     // updateWaterState() in yarn
@@ -2668,9 +2364,17 @@ impl Entity {
         self.world.load().remove_entity(self);
     }
 
+    /// Vanilla `ClientboundAddEntityPacket(entity, serverEntity)`: tracker, not live.
+    fn spawn_pos_vel(&self) -> (Vector3<f64>, Vector3<f64>) {
+        if self.entity_type == &EntityType::PLAYER {
+            (self.pos.load(), self.velocity.load())
+        } else {
+            (self.last_sent_pos.load(), self.last_sent_velocity.load())
+        }
+    }
+
     pub fn create_spawn_packet(&self) -> CSpawnEntity {
-        let entity_loc = self.pos.load();
-        let entity_vel = self.velocity.load();
+        let (entity_loc, entity_vel) = self.spawn_pos_vel();
         CSpawnEntity::new(
             VarInt(self.entity_id),
             self.entity_uuid,
@@ -2685,8 +2389,7 @@ impl Entity {
     }
 
     pub fn create_spawn_living_packet(&self, metadata: Option<Box<[u8]>>) -> CSpawnLivingEntity {
-        let entity_loc = self.pos.load();
-        let entity_vel = self.velocity.load();
+        let (entity_loc, entity_vel) = self.spawn_pos_vel();
         CSpawnLivingEntity::new(
             VarInt(self.entity_id),
             self.entity_uuid,
@@ -3023,12 +2726,8 @@ impl Entity {
         tracked: pumpkin_data::tracked_data::TrackedData,
         value: T,
     ) -> bool {
-        if self.synched_data.set(tracked, value) {
-            self.send_dirty_entity_data();
-            true
-        } else {
-            false
-        }
+        // Sent by the tracker at end of tick, vanilla `sendDirtyEntityData`.
+        self.synched_data.set(tracked, value)
     }
 
     pub fn send_bedrock_actor_data(&self, bedrock_meta: &SyncedActorDataList) {

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -358,6 +358,8 @@ pub trait EntityBase: Send + Sync + std::any::Any {
             y_body_rotation: entity.body_yaw.load(),
             attributes_list: Vec::new(),
             actor_data: metadata,
+            // TODO: Bedrock `climate_variant` property for pig/cow/chicken (`TemperatureVariantAnimal`)
+            // empty -> client picks its own variant.
             synced_properties: PropertySyncData {
                 int_entries_list: std::collections::HashMap::new(),
                 float_entries_list: std::collections::HashMap::new(),

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -31,7 +31,11 @@ use pumpkin_protocol::bedrock::client::{
 };
 use pumpkin_protocol::bedrock::client::{
     SerializedAbilitiesDataSerializedLayer,
+    add_player::CAddPlayer,
+    common::BuildPlatform,
     move_player::CMovePlayer as CBedrockMovePlayer,
+    player_list::{CPlayerList, PlayerListEntry},
+    set_actor_data::PropertySyncData,
     update_attributes::{
         AttributeData as BedrockAttribute, CUpdateAttributes as CBedrockAttributes,
     },
@@ -976,6 +980,62 @@ impl Player {
         F::Output: Send + 'static,
     {
         self.client.spawn_task(task)
+    }
+
+    /// Bedrock remote-player spawn -> the `PlayerList` entry must precede `AddPlayer`.
+    #[must_use]
+    pub fn bedrock_spawn_packets(&self) -> (CPlayerList, CAddPlayer) {
+        let entity = self.get_entity();
+        let entity_id = i64::from(self.entity_id());
+        let profile = &self.gameprofile;
+        let player_list = CPlayerList {
+            action: CPlayerList::ACTION_ADD,
+            entries: vec![PlayerListEntry {
+                uuid: profile.id,
+                entity_unique_id: VarLong(entity_id),
+                username: profile.name.clone(),
+                xuid: String::new(),
+                platform_chat_id: String::new(),
+                build_platform: BuildPlatform::Unknown,
+                skin: (**self.bedrock_skin.load()).clone(),
+                is_teacher: false,
+                is_host: false,
+                is_sub_client: false,
+                player_color: [0; 4],
+            }],
+        };
+        let add_player = CAddPlayer {
+            uuid: profile.id,
+            player_name: profile.name.clone(),
+            target_runtime_id: VarULong(entity_id as u64),
+            platform_chat_id: String::new(),
+            position: entity.pos.load().to_f32_lossy(),
+            velocity: entity.velocity.load().to_f32_lossy(),
+            rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
+            y_head_rotation: entity.head_yaw.load(),
+            carried_item:
+                pumpkin_protocol::bedrock::network_item::NetworkItemStackDescriptor::default(),
+            player_game_type: self.gamemode.load().into(),
+            entity_data: entity.bedrock_metadata(),
+            synced_properties: PropertySyncData::default(),
+            abilities_data: SerializedAbilitiesData {
+                target_player_raw_id: entity_id,
+                player_permissions: PlayerPermissionLevel::Visitor,
+                command_permissions: CommandPermissionLevel::Any,
+                layers: vec![SerializedAbilitiesDataSerializedLayer {
+                    serialized_layer: 0,
+                    abilities_set: 0,
+                    ability_value: 0,
+                    fly_speed: 0.05,
+                    vertical_fly_speed: 0.05,
+                    walk_speed: 0.1,
+                }],
+            },
+            actor_links: Vec::new(),
+            device_id: String::new(),
+            build_platform: BuildPlatform::Unknown,
+        };
+        (player_list, add_player)
     }
 
     pub const fn inventory(&self) -> &Arc<PlayerInventory> {
@@ -6532,6 +6592,28 @@ impl EntityBase for Player {
 
     fn get_player(&self) -> Option<&Player> {
         Some(self)
+    }
+
+    /// Bedrock renders remote players only from `AddPlayer`, never `AddActor`.
+    fn send_bedrock_spawn_packet(&self, client: &crate::net::bedrock::BedrockClient) {
+        let (player_list, add_player) = self.bedrock_spawn_packets();
+        let equipment = pumpkin_protocol::bedrock::client::CMobEquipment {
+            target_runtime_id: (self.entity_id() as u64).into(),
+            item: (&self.inventory.held_item()).into(),
+            slot: 0,
+            selected_slot: 0,
+            container_id: 0,
+        };
+        for data in [
+            client.serialize_packet(&player_list),
+            client.serialize_packet(&add_player),
+            client.serialize_packet(&equipment),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            client.try_enqueue_packet(data);
+        }
     }
 
     fn is_spectator(&self) -> bool {

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -982,18 +982,15 @@ impl Player {
         self.client.spawn_task(task)
     }
 
-    /// Bedrock remote-player spawn -> the `PlayerList` entry must precede `AddPlayer`.
+    /// Bedrock tab-list entry -> carries the skin, so it must precede `AddPlayer`.
     #[must_use]
-    pub fn bedrock_spawn_packets(&self) -> (CPlayerList, CAddPlayer) {
-        let entity = self.get_entity();
-        let entity_id = i64::from(self.entity_id());
-        let profile = &self.gameprofile;
-        let player_list = CPlayerList {
+    pub fn bedrock_player_list(&self) -> CPlayerList {
+        CPlayerList {
             action: CPlayerList::ACTION_ADD,
             entries: vec![PlayerListEntry {
-                uuid: profile.id,
-                entity_unique_id: VarLong(entity_id),
-                username: profile.name.clone(),
+                uuid: self.gameprofile.id,
+                entity_unique_id: VarLong(i64::from(self.entity_id())),
+                username: self.gameprofile.name.clone(),
                 xuid: String::new(),
                 platform_chat_id: String::new(),
                 build_platform: BuildPlatform::Unknown,
@@ -1003,7 +1000,21 @@ impl Player {
                 is_sub_client: false,
                 player_color: [0; 4],
             }],
-        };
+        }
+    }
+
+    /// Bedrock remote-player spawn -> the `PlayerList` entry must precede `AddPlayer`.
+    #[must_use]
+    pub fn bedrock_spawn_packets(&self) -> (CPlayerList, CAddPlayer) {
+        let entity = self.get_entity();
+        let entity_id = i64::from(self.entity_id());
+        let profile = &self.gameprofile;
+        let mut entity_data = entity.bedrock_metadata();
+        // name tag only shows on the crosshair without this.
+        entity_data.set(
+            pumpkin_protocol::bedrock::client::set_actor_data::entity_data_key::ALWAYS_SHOW_NAME_TAG,
+            pumpkin_protocol::bedrock::client::set_actor_data::MetadataValue::Byte(1),
+        );
         let add_player = CAddPlayer {
             uuid: profile.id,
             player_name: profile.name.clone(),
@@ -1016,7 +1027,7 @@ impl Player {
             carried_item:
                 pumpkin_protocol::bedrock::network_item::NetworkItemStackDescriptor::default(),
             player_game_type: self.gamemode.load().into(),
-            entity_data: entity.bedrock_metadata(),
+            entity_data,
             synced_properties: PropertySyncData::default(),
             abilities_data: SerializedAbilitiesData {
                 target_player_raw_id: entity_id,
@@ -1035,7 +1046,7 @@ impl Player {
             device_id: String::new(),
             build_platform: BuildPlatform::Unknown,
         };
-        (player_list, add_player)
+        (self.bedrock_player_list(), add_player)
     }
 
     pub const fn inventory(&self) -> &Arc<PlayerInventory> {

--- a/crates/pumpkin/src/entity/projectile/eye_of_ender.rs
+++ b/crates/pumpkin/src/entity/projectile/eye_of_ender.rs
@@ -143,7 +143,6 @@ impl EntityBase for EyeOfEnder {
         }
 
         entity.set_pos(new_pos);
-        entity.send_pos_rot();
 
         // Tick lifetime and handle expiry.
         let life = self.life.fetch_add(1, Ordering::Relaxed) + 1;

--- a/crates/pumpkin/src/entity/projectile/shulker_bullet.rs
+++ b/crates/pumpkin/src/entity/projectile/shulker_bullet.rs
@@ -8,7 +8,6 @@ use pumpkin_data::entity::EntityType;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::potion::Effect;
 use pumpkin_data::sound::{Sound, SoundCategory};
-use pumpkin_protocol::java::client::play::{CEntityPositionSync, CEntityVelocity};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use rand::RngExt;
@@ -414,24 +413,6 @@ impl EntityBase for ShulkerBulletEntity {
         let old_pos = entity.pos.load();
         let new_pos = old_pos.add(&vel);
         entity.set_pos(new_pos);
-
-        // Broadcast position and velocity
-        let chunk_pos = entity.chunk_pos.load();
-        world.broadcast_to_chunk(
-            chunk_pos,
-            &CEntityPositionSync::new(
-                entity.entity_id.into(),
-                new_pos,
-                vel,
-                entity.yaw.load(),
-                entity.pitch.load(),
-                false,
-            ),
-        );
-        world.broadcast_to_chunk(
-            chunk_pos,
-            &CEntityVelocity::new(entity.entity_id.into(), vel),
-        );
 
         // Check for block collisions
         let new_bp = entity.block_pos.load();

--- a/crates/pumpkin/src/entity/tnt.rs
+++ b/crates/pumpkin/src/entity/tnt.rs
@@ -48,11 +48,6 @@ impl EntityBase for TNTEntity {
             entity.velocity.store(velo.multiply(0.98, 0.98, 0.98));
         }
 
-        if entity.velocity_dirty.swap(false, Ordering::SeqCst) {
-            entity.send_pos_rot();
-            entity.send_velocity();
-        }
-
         // FIX: Prevent fuse underflow (vanilla parity)
         let fuse = self.fuse.load(Relaxed);
 
@@ -99,6 +94,12 @@ impl EntityBase for TNTEntity {
     fn get_gravity(&self) -> f64 {
         0.04
     }
+
+    // TODO: Bedrock lacks fuse metadata, ignited flag, prime sound and particles: no blink.
+    fn bedrock_y_offset(&self) -> f64 {
+        0.49
+    }
+
     fn cast_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/pumpkin/src/entity/type.rs
+++ b/crates/pumpkin/src/entity/type.rs
@@ -6,7 +6,7 @@ use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use uuid::Uuid;
 
-use crate::entity::boss::ender_dragon::EnderDragonEntity;
+use crate::entity::boss::ender_dragon::{EnderDragonEntity, PART_DIMENSIONS};
 use crate::entity::boss::wither::WitherEntity;
 use crate::entity::decoration::{
     armor_stand::ArmorStandEntity,
@@ -135,7 +135,13 @@ pub fn from_type(
     world: &Arc<World>,
     uuid: Uuid,
 ) -> Arc<dyn EntityBase> {
-    let entity = Entity::from_uuid(uuid, world.clone(), position, entity_type);
+    let entity = if entity_type.id == EntityType::ENDER_DRAGON.id {
+        // The client derives the 8 part ids from the dragon's, so reserve them together.
+        let base_id = Entity::reserve_ids(1 + PART_DIMENSIONS.len() as i32);
+        Entity::from_uuid_with_id(base_id, uuid, world.clone(), position, entity_type)
+    } else {
+        Entity::from_uuid(uuid, world.clone(), position, entity_type)
+    };
 
     let mob: Arc<dyn EntityBase> = match entity_type.id {
         // Zombie

--- a/crates/pumpkin/src/entity/vehicle/minecart.rs
+++ b/crates/pumpkin/src/entity/vehicle/minecart.rs
@@ -432,8 +432,6 @@ impl EntityBase for MinecartEntity {
                 }
             }
 
-            self.vehicle.entity.send_pos_rot();
-
             #[allow(clippy::useless_let_if_seq)]
             let mut friction = 0.95; // Vanilla minecart air drag
 

--- a/crates/pumpkin/src/net/bedrock/level_chunk.rs
+++ b/crates/pumpkin/src/net/bedrock/level_chunk.rs
@@ -76,24 +76,27 @@ impl CLevelChunk<'_> {
         VarInt(chunk.z).write(&mut writer)?;
 
         VarInt(dimension).write(&mut writer)?;
-        let sub_chunk_count = chunk.section.count as u32;
-        VarUInt(sub_chunk_count).write(&mut writer)?;
-        // Optional sub-chunk request limit. Pumpkin sends complete chunks.
-        false.write(&mut writer)?;
-        cache_enabled.write(&mut writer)?;
-
-        let mut blobs = Vec::new();
-
         let block_sections = chunk
             .section
             .block_sections
             .read()
             .map_err(|_| Error::other("block_sections read lock poisoned"))?;
+        // all-air sub-chunks above the highest non-air one are not sent.
+        let sub_chunk_count = block_sections
+            .iter()
+            .rposition(|section| !section.has_only_air())
+            .map_or(0, |index| index + 1);
+        VarUInt(sub_chunk_count as u32).write(&mut writer)?;
+        // Optional sub-chunk request limit. Pumpkin sends complete chunks otherwise.
+        false.write(&mut writer)?;
+        cache_enabled.write(&mut writer)?;
+
+        let mut blobs = Vec::new();
         let min_y_section = (chunk.section.min_y >> 4) as i8;
 
-        let mut subchunk_bytes_list = Vec::with_capacity(block_sections.len());
+        let mut subchunk_bytes_list = Vec::with_capacity(sub_chunk_count);
 
-        for (i, block_palette) in block_sections.iter().enumerate() {
+        for (i, block_palette) in block_sections.iter().take(sub_chunk_count).enumerate() {
             let mut subchunk_buf = Vec::new();
             // Version 9: [version:byte][num_storages:byte][sub_chunk_index:byte]
             let y = (i as i8) + min_y_section;
@@ -262,7 +265,7 @@ mod tests {
         for _ in 0..3 {
             read_var_uint(&encoded, &mut offset);
         }
-        assert_eq!(read_var_uint(&encoded, &mut offset), 24);
+        assert_eq!(read_var_uint(&encoded, &mut offset), 0); // All air -> no sub-chunks.
         assert_eq!(encoded[offset], 0); // No sub-chunk request limit.
         assert_eq!(encoded[offset + 1], 0); // Cache disabled.
         offset += 2;
@@ -272,13 +275,6 @@ mod tests {
         assert_eq!(raw.len(), raw_len);
 
         let mut raw_offset = 0;
-        for y in -4i8..20 {
-            assert_eq!(&raw[raw_offset..raw_offset + 3], &[9, 1, y as u8]);
-            raw_offset += 3;
-            assert_eq!(raw[raw_offset], 1); // Single-value block palette.
-            raw_offset += 1;
-            read_var_uint(raw, &mut raw_offset);
-        }
         for _ in 0..24 {
             assert_eq!(raw[raw_offset], 1); // No version/storage/Y prefix.
             raw_offset += 1;
@@ -286,6 +282,22 @@ mod tests {
         }
         assert_eq!(raw[raw_offset], 0); // Border block count.
         assert_eq!(raw_offset + 1, raw.len());
+    }
+
+    #[test]
+    fn trailing_air_sub_chunks_are_not_sent() {
+        let chunk = empty_chunk();
+        chunk
+            .section
+            .set_block_absolute_y(0, 0, 0, Block::STONE.default_state.id);
+
+        let (encoded, _) = CLevelChunk::encode_chunk(&chunk, 0, false, &[]).unwrap();
+        let mut offset = 0;
+        for _ in 0..3 {
+            read_var_uint(&encoded, &mut offset);
+        }
+        // y = 0 is sub-chunk index 4 above min_y -64.
+        assert_eq!(read_var_uint(&encoded, &mut offset), 5);
     }
 
     #[test]

--- a/crates/pumpkin/src/world/dragon_fight.rs
+++ b/crates/pumpkin/src/world/dragon_fight.rs
@@ -19,7 +19,9 @@ use super::{
     World,
     bossbar::{Bossbar, BossbarColor, BossbarDivisions, BossbarFlags},
 };
-use crate::entity::{Entity, EntityBase, decoration::end_crystal::EndCrystalEntity};
+use crate::entity::{
+    Entity, EntityBase, decoration::end_crystal::EndCrystalEntity, player::Player,
+};
 
 // ── Constants (match vanilla exactly) ────────────────────────────────────────
 
@@ -73,9 +75,12 @@ pub struct DragonFight {
     ticks_since_crystals_scanned: i32,
     ticks_since_last_player_scan: i32,
 
-    // ── Boss bar ──────────────────────────────────────────────────────────────
+    // ── Boss bar (vanilla `ServerBossEvent`) ──────────────────────────────────
     bossbar_uuid: Uuid,
-    bossbar_players: Vec<Uuid>,
+    bossbar_players: Vec<Arc<Player>>,
+    bossbar_visible: bool,
+    bossbar_progress: f32,
+    bossbar_title: Option<String>,
 }
 
 impl Default for DragonFight {
@@ -124,6 +129,9 @@ impl DragonFight {
             ticks_since_last_player_scan: TIME_BETWEEN_PLAYER_SCANS + 1,
             bossbar_uuid: Uuid::new_v4(),
             bossbar_players: Vec::new(),
+            bossbar_visible: true,
+            bossbar_progress: 1.0,
+            bossbar_title: None,
         }
     }
 
@@ -155,6 +163,11 @@ impl DragonFight {
         let mut fight = fight_mutex
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Vanilla sets the visibility before the player scan, so a bar that must not
+        // be shown is never added and never receives updates.
+        let dragon_killed = fight.dragon_killed;
+        fight.set_bossbar_visible(!dragon_killed);
 
         // 1. Update boss-bar recipients every 20 ticks
         fight.ticks_since_last_player_scan += 1;
@@ -465,10 +478,10 @@ impl DragonFight {
         } else {
             0.0
         };
-        self.update_bossbar_health(world, fraction);
+        self.update_bossbar_health(fraction);
 
         if let Some(name) = custom_name {
-            self.update_bossbar_title(world, name);
+            self.update_bossbar_title(name);
         }
 
         if let Some(loc) = self.exit_portal_location
@@ -491,8 +504,9 @@ impl DragonFight {
             return;
         }
 
-        self.update_bossbar_health(world, 0.0);
-        self.remove_all_bossbar(world);
+        // Vanilla keeps the viewers and only hides the bar.
+        self.update_bossbar_health(0.0);
+        self.set_bossbar_visible(false);
 
         // Activate the exit portal.
         self.spawn_exit_portal(world, true);
@@ -1036,36 +1050,59 @@ impl DragonFight {
                 "entity.minecraft.ender_dragon",
                 Vec::<TextComponent>::new(),
             ),
-            health: 1.0,
+            health: self.bossbar_progress,
             color: BossbarColor::Pink,
             division: BossbarDivisions::NoDivision,
             flags: BossbarFlags::DRAGON_BAR | BossbarFlags::CREATE_FOG | BossbarFlags::DARKEN_SKY,
         }
     }
 
-    fn update_bossbar_health(&self, world: &Arc<World>, health: f32) {
-        for player in world.players.load().iter() {
-            if self.bossbar_players.contains(&player.gameprofile.id) {
-                player.update_bossbar_health(&self.bossbar_uuid, health);
-            }
+    /// Vanilla `ServerBossEvent.setVisible` -> the bar is shown while the dragon is alive.
+    fn set_bossbar_visible(&mut self, visible: bool) {
+        if self.bossbar_visible == visible {
+            return;
         }
-    }
+        self.bossbar_visible = visible;
 
-    fn update_bossbar_title(&self, world: &Arc<World>, title: &TextComponent) {
-        for player in world.players.load().iter() {
-            if self.bossbar_players.contains(&player.gameprofile.id) {
-                player.update_bossbar_title(&self.bossbar_uuid, title.clone());
-            }
-        }
-    }
-
-    fn remove_all_bossbar(&mut self, world: &Arc<World>) {
-        for player in world.players.load().iter() {
-            if self.bossbar_players.contains(&player.gameprofile.id) {
+        let bossbar = self.make_bossbar();
+        for player in &self.bossbar_players {
+            if visible {
+                player.send_bossbar(&bossbar);
+            } else {
                 player.remove_bossbar(self.bossbar_uuid);
             }
         }
-        self.bossbar_players.clear();
+    }
+
+    /// Vanilla `ServerBossEvent.setProgress`-> only on change, and only while visible.
+    fn update_bossbar_health(&mut self, health: f32) {
+        if self.bossbar_progress == health {
+            return;
+        }
+        self.bossbar_progress = health;
+
+        if !self.bossbar_visible {
+            return;
+        }
+        for player in &self.bossbar_players {
+            player.update_bossbar_health(&self.bossbar_uuid, health);
+        }
+    }
+
+    /// Vanilla `ServerBossEvent.setName`.
+    fn update_bossbar_title(&mut self, title: &TextComponent) {
+        let text = title.clone().get_text();
+        if self.bossbar_title.as_deref() == Some(text.as_str()) {
+            return;
+        }
+        self.bossbar_title = Some(text);
+
+        if !self.bossbar_visible {
+            return;
+        }
+        for player in &self.bossbar_players {
+            player.update_bossbar_title(&self.bossbar_uuid, title.clone());
+        }
     }
 
     fn update_players(&mut self, world: &Arc<World>) {
@@ -1074,7 +1111,7 @@ impl DragonFight {
         let origin_x = self.origin.0.x as f64;
         let origin_z = self.origin.0.z as f64;
 
-        let current: Vec<Uuid> = players
+        let current: Vec<Arc<Player>> = players
             .iter()
             .filter(|p| {
                 let pos = p.living_entity.entity.pos.load();
@@ -1083,35 +1120,39 @@ impl DragonFight {
                 let dz = pos.z - origin_z;
                 dx * dx + dy * dy + dz * dz < ARENA_RADIUS * ARENA_RADIUS
             })
-            .map(|p| p.gameprofile.id)
+            .cloned()
             .collect();
 
         // Add newly-in-range players
-        for &uid in &current {
-            if !self.bossbar_players.contains(&uid) {
-                if !self.dragon_killed
-                    && let Some(p) = players.iter().find(|p| p.gameprofile.id == uid)
-                {
-                    p.send_bossbar(&self.make_bossbar());
+        for player in &current {
+            if !self
+                .bossbar_players
+                .iter()
+                .any(|known| known.gameprofile.id == player.gameprofile.id)
+            {
+                if self.bossbar_visible {
+                    player.send_bossbar(&self.make_bossbar());
                 }
-                self.bossbar_players.push(uid);
+                self.bossbar_players.push(player.clone());
             }
         }
 
-        // Remove out-of-range players
-        let to_remove: Vec<Uuid> = self
-            .bossbar_players
-            .iter()
-            .filter(|uid| !current.contains(uid))
-            .copied()
-            .collect();
-
-        for uid in &to_remove {
-            if let Some(player) = players.iter().find(|player| &player.gameprofile.id == uid) {
-                player.remove_bossbar(self.bossbar_uuid);
+        // Remove out-of-range players. Vanilla holds the players itself, so this also
+        // reaches players who left the dimension or disconnected.
+        let uuid = self.bossbar_uuid;
+        let visible = self.bossbar_visible;
+        self.bossbar_players.retain(|known| {
+            if current
+                .iter()
+                .any(|player| player.gameprofile.id == known.gameprofile.id)
+            {
+                return true;
             }
-            self.bossbar_players.retain(|u| u != uid);
-        }
+            if visible {
+                known.remove_bossbar(uuid);
+            }
+            false
+        });
     }
 
     // ── Public queries ────────────────────────────────────────────────────────

--- a/crates/pumpkin/src/world/dragon_fight.rs
+++ b/crates/pumpkin/src/world/dragon_fight.rs
@@ -245,19 +245,18 @@ impl DragonFight {
         };
 
         match existing {
-            Some((uuid, _entity)) if !active_portal_exists => {
+            Some((uuid, entity)) => {
                 info!("Found that there's a dragon still alive ({:?})", uuid);
                 self.dragon_uuid = Some(uuid);
                 self.dragon_killed = false;
-            }
-            Some((uuid, entity)) => {
-                info!(
-                    "Found that there's a dragon still alive ({:?}), but we have an active portal. Removing it.",
-                    uuid
-                );
-                entity.get_entity().remove();
-                self.dragon_uuid = None;
-                self.dragon_killed = true;
+                // A dragon without any portal is a pre-1.9 world removed so a
+                // fresh one can spawn. An active portal means a finished fight, and the
+                // dragon then belongs to a later respawn.
+                if !active_portal_exists {
+                    info!("But we didn't have a portal, let's remove it.");
+                    entity.get_entity().remove();
+                    self.dragon_uuid = None;
+                }
             }
             None => {
                 self.dragon_killed = true;
@@ -1022,6 +1021,12 @@ impl DragonFight {
     // ── Exit portal ───────────────────────────────────────────────────────────
 
     pub fn spawn_exit_portal(&mut self, world: &Arc<World>, active: bool) {
+        // Vanilla restores the location from saved data. Without that, look the podium
+        // up first.
+        if self.exit_portal_location.is_none() {
+            self.find_exit_portal(world);
+        }
+
         if self.exit_portal_location.is_none() {
             let mut portal_y = 65;
             for y in (50..=100).rev() {

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -122,8 +122,8 @@ impl TrackedEntity {
             if self.seen_by.insert(player.gameprofile.id) {
                 self.add_pairing(player);
             }
-        } else if self.seen_by.remove(&player.gameprofile.id).is_some() {
-            self.remove_pairing(player);
+        } else {
+            self.remove_player(player);
         }
     }
 
@@ -136,6 +136,7 @@ impl TrackedEntity {
     #[allow(clippy::too_many_lines)]
     pub fn add_pairing(&self, player: &Arc<Player>) {
         player.client.try_enqueue_spawn_packet(&self.entity);
+        player.try_restore_vehicle(&self.entity);
 
         if let Some(target_player) = self.entity.get_player() {
             let skin_parts = target_player.config.load().skin_parts;
@@ -273,7 +274,7 @@ impl TrackedEntity {
         }
     }
 
-    pub fn remove_pairing(&self, player: &Arc<Player>) {
+    pub fn remove_pairing(&self, player: &Player) {
         let entity_ids = [self.entity_id.into()];
         match player.client.as_ref() {
             ClientPlatform::Java(client) => {
@@ -317,8 +318,11 @@ impl TrackedEntity {
         self.seen_by.clear();
     }
 
-    pub fn remove_player(&self, player_uuid: &Uuid) {
-        self.seen_by.remove(player_uuid);
+    /// Vanilla `TrackedEntity.removePlayer`: despawn on the client, only if it was paired.
+    pub fn remove_player(&self, player: &Player) {
+        if self.seen_by.remove(&player.gameprofile.id).is_some() {
+            self.remove_pairing(player);
+        }
     }
 
     pub fn send_to_tracking_players<P: ClientPacket + Sync>(&self, packet: &P, world: &World) {
@@ -525,9 +529,8 @@ impl EntityTracker {
     pub fn remove_entity(&self, entity: &dyn EntityBase, world: &World) {
         let entity_id = entity.get_entity().entity_id;
         if let Some(player) = entity.get_player() {
-            let player_id = player.gameprofile.id;
             for entry in &self.entity_map {
-                entry.value().remove_player(&player_id);
+                entry.value().remove_player(player);
             }
         }
 

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -75,6 +75,8 @@ pub struct TrackedEntity {
     pub update_interval: u32,
     pub track_deltas: bool,
     pub seen_by: DashSet<Uuid>,
+    /// Bedrock players in `seen_by`.
+    bedrock_watchers: AtomicU32,
     pub last_section_pos: AtomicCell<Vector3<i32>>,
     tick_count: AtomicU32,
     teleport_delay: AtomicU32,
@@ -121,6 +123,7 @@ impl TrackedEntity {
             update_interval,
             track_deltas,
             seen_by: DashSet::new(),
+            bedrock_watchers: AtomicU32::new(0),
             last_section_pos: AtomicCell::new(last_section_pos),
             tick_count: AtomicU32::new(0),
             teleport_delay: AtomicU32::new(0),
@@ -335,6 +338,9 @@ impl TrackedEntity {
             self.bedrock_pos.store(pos);
         }
         self.bedrock_rot.store(rot);
+        if self.bedrock_watchers.load(Relaxed) == 0 {
+            return;
+        }
         if entity.on_ground.load(Relaxed) {
             flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
         }
@@ -411,6 +417,9 @@ impl TrackedEntity {
 
         if is_visible {
             if self.seen_by.insert(player.gameprofile.id) {
+                if matches!(player.client.as_ref(), ClientPlatform::Bedrock(_)) {
+                    self.bedrock_watchers.fetch_add(1, Relaxed);
+                }
                 self.add_pairing(player);
             }
         } else {
@@ -584,6 +593,9 @@ impl TrackedEntity {
     }
 
     pub fn broadcast_removed(&self, world: &World) {
+        if self.seen_by.is_empty() {
+            return;
+        }
         let entity_ids = [self.entity_id.into()];
         let je_packet = CRemoveEntities::new(&entity_ids);
         let be_packet = CRemoveActor::new(VarLong(i64::from(self.entity_id)));
@@ -607,16 +619,23 @@ impl TrackedEntity {
         World::broadcast_bedrock_grouped(&be_packet, bedrock_recipients.into_iter());
 
         self.seen_by.clear();
+        self.bedrock_watchers.store(0, Relaxed);
     }
 
     /// Vanilla `TrackedEntity.removePlayer`: despawn on the client, only if it was paired.
     pub fn remove_player(&self, player: &Player) {
         if self.seen_by.remove(&player.gameprofile.id).is_some() {
+            if matches!(player.client.as_ref(), ClientPlatform::Bedrock(_)) {
+                self.bedrock_watchers.fetch_sub(1, Relaxed);
+            }
             self.remove_pairing(player);
         }
     }
 
     pub fn send_to_tracking_players<P: ClientPacket + Sync>(&self, packet: &P, world: &World) {
+        if self.seen_by.is_empty() {
+            return;
+        }
         let players = world.players.load();
         let recipients = players
             .iter()
@@ -630,6 +649,9 @@ impl TrackedEntity {
         packet: &P,
         world: &World,
     ) {
+        if self.bedrock_watchers.load(Relaxed) == 0 {
+            return;
+        }
         let players = world.players.load();
         let recipients = players.iter().filter_map(|p| {
             if self.seen_by.contains(&p.gameprofile.id)
@@ -648,6 +670,9 @@ impl TrackedEntity {
         be_packet: &B,
         world: &World,
     ) {
+        if self.seen_by.is_empty() {
+            return;
+        }
         let players = world.players.load();
         let recipients = players
             .iter()

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -393,6 +393,10 @@ impl TrackedEntity {
     }
 
     pub fn update_player(&self, player: &Arc<Player>, _world: &World) {
+        self.update_player_in_range(player, self.get_effective_range());
+    }
+
+    fn update_player_in_range(&self, player: &Arc<Player>, effective_range: u32) {
         if player.get_entity().entity_id == self.entity_id {
             return;
         }
@@ -405,7 +409,6 @@ impl TrackedEntity {
         let dist_sq = dx.mul_add(dx, dz * dz);
 
         let player_vd = get_view_distance(player).get() as i32;
-        let effective_range = self.get_effective_range();
         let visible_range_blocks = f64::from((effective_range as i32).min(player_vd) * 16);
         let range_sq = visible_range_blocks * visible_range_blocks;
 
@@ -427,9 +430,10 @@ impl TrackedEntity {
         }
     }
 
-    pub fn update_players(&self, players: &[Arc<Player>], world: &World) {
+    pub fn update_players(&self, players: &[Arc<Player>], _world: &World) {
+        let effective_range = self.get_effective_range();
         for player in players {
-            self.update_player(player, world);
+            self.update_player_in_range(player, effective_range);
         }
     }
 

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -134,6 +134,11 @@ impl TrackedEntity {
         }
     }
 
+    #[must_use]
+    pub fn has_bedrock_watchers(&self) -> bool {
+        self.bedrock_watchers.load(Relaxed) > 0
+    }
+
     /// Vanilla `ServerEntity.sendChanges`. Non-player entities only.
     pub fn send_changes(&self, world: &World) {
         let entity = self.entity.get_entity();
@@ -338,7 +343,7 @@ impl TrackedEntity {
             self.bedrock_pos.store(pos);
         }
         self.bedrock_rot.store(rot);
-        if self.bedrock_watchers.load(Relaxed) == 0 {
+        if !self.has_bedrock_watchers() {
             return;
         }
         if entity.on_ground.load(Relaxed) {
@@ -653,7 +658,7 @@ impl TrackedEntity {
         packet: &P,
         world: &World,
     ) {
-        if self.bedrock_watchers.load(Relaxed) == 0 {
+        if !self.has_bedrock_watchers() {
             return;
         }
         let players = world.players.load();

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -1,15 +1,28 @@
 use std::sync::Arc;
+use std::sync::atomic::{
+    AtomicBool, AtomicU32,
+    Ordering::{self, Relaxed},
+};
 
 use bytes::BufMut;
 use crossbeam::atomic::AtomicCell;
 use dashmap::DashMap;
 use dashmap::DashSet;
+use pumpkin_data::entity::EntityType;
+use pumpkin_protocol::bedrock::client::CSetActorMotion;
+use pumpkin_protocol::bedrock::client::move_actor_delta::{
+    CMoveActorDelta, MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW, MOVE_ACTOR_DELTA_FLAG_HAS_PITCH,
+    MOVE_ACTOR_DELTA_FLAG_HAS_X, MOVE_ACTOR_DELTA_FLAG_HAS_Y, MOVE_ACTOR_DELTA_FLAG_HAS_YAW,
+    MOVE_ACTOR_DELTA_FLAG_HAS_Z, MOVE_ACTOR_DELTA_FLAG_ON_GROUND,
+};
 use pumpkin_protocol::bedrock::client::remove_actor::CRemoveActor;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::codec::var_long::VarLong;
+use pumpkin_protocol::codec::var_ulong::VarULong;
 use pumpkin_protocol::java::client::play::{
-    CEntityVelocity, CHeadRot, CRemoveEntities, CSetEntityMetadata, CSetEquipment, CSetPassengers,
+    CEntityPositionSync, CEntityVelocity, CHeadRot, CRemoveEntities, CSetEntityMetadata,
+    CSetEquipment, CSetPassengers, CUpdateEntityPos, CUpdateEntityPosRot, CUpdateEntityRot,
     Metadata,
 };
 use pumpkin_protocol::{BClientPacket, ClientPacket};
@@ -19,12 +32,41 @@ use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::version::JavaMinecraftVersion;
 use uuid::Uuid;
 
-use crate::entity::EntityBase;
 use crate::entity::player::Player;
+use crate::entity::{Entity, EntityBase};
 use crate::net::ClientPlatform;
 use crate::net::java::JavaClient;
 use crate::world::World;
 use crate::world::chunker::{get_view_distance, is_within_view_distance};
+
+/// Vanilla `VecDeltaCodec.encode`: Java `Math.round` on the 1/4096
+fn encode_pos(value: f64) -> i64 {
+    (value * 4096.0 + 0.5).floor() as i64
+}
+
+/// Vanilla `Mth.packDegrees`.
+fn pack_degrees(degrees: f32) -> u8 {
+    (degrees * 256.0 / 360.0).floor() as i32 as u8
+}
+
+/// Vanilla `ServerEntity.sendChanges` packet choice.
+#[derive(Clone, Copy)]
+enum MoveSync {
+    Pos(Vector3<i16>),
+    Rot,
+    PosRot(Vector3<i16>),
+    Absolute,
+}
+
+impl MoveSync {
+    const fn sends_position(self) -> bool {
+        !matches!(self, Self::Rot)
+    }
+
+    const fn sends_rotation(self) -> bool {
+        !matches!(self, Self::Pos(_))
+    }
+}
 
 pub struct TrackedEntity {
     pub entity: Arc<dyn EntityBase>,
@@ -34,6 +76,13 @@ pub struct TrackedEntity {
     pub track_deltas: bool,
     pub seen_by: DashSet<Uuid>,
     pub last_section_pos: AtomicCell<Vector3<i32>>,
+    tick_count: AtomicU32,
+    teleport_delay: AtomicU32,
+    was_on_ground: AtomicBool,
+    was_riding: AtomicBool,
+    bedrock_pos: AtomicCell<Vector3<f64>>,
+    /// Packed pitch, yaw, head yaw.
+    bedrock_rot: AtomicCell<[u8; 3]>,
 }
 
 impl TrackedEntity {
@@ -44,8 +93,22 @@ impl TrackedEntity {
         update_interval: u32,
         track_deltas: bool,
     ) -> Self {
-        let entity_id = entity.get_entity().entity_id;
-        let pos = entity.get_entity().pos.load();
+        let base = entity.get_entity();
+        let entity_id = base.entity_id;
+        let pos = base.pos.load();
+        let on_ground = base.on_ground.load(Relaxed);
+        let bedrock_pos = entity.bedrock_pos();
+        let rot = [
+            pack_degrees(base.pitch.load()),
+            pack_degrees(base.yaw.load()),
+            pack_degrees(base.head_yaw.load()),
+        ];
+        // Vanilla `ServerEntity` ctor: sync state starts at the current values.
+        base.last_sent_pos.store(pos);
+        base.last_sent_velocity.store(base.velocity.load());
+        base.last_sent_pitch.store(rot[0], Relaxed);
+        base.last_sent_yaw.store(rot[1], Relaxed);
+        base.last_sent_head_yaw.store(rot[2], Relaxed);
         let last_section_pos = Vector3::new(
             get_section_cord(pos.x.floor() as i32),
             get_section_cord(pos.y.floor() as i32),
@@ -59,7 +122,235 @@ impl TrackedEntity {
             track_deltas,
             seen_by: DashSet::new(),
             last_section_pos: AtomicCell::new(last_section_pos),
+            tick_count: AtomicU32::new(0),
+            teleport_delay: AtomicU32::new(0),
+            was_on_ground: AtomicBool::new(on_ground),
+            was_riding: AtomicBool::new(false),
+            bedrock_pos: AtomicCell::new(bedrock_pos),
+            bedrock_rot: AtomicCell::new(rot),
         }
+    }
+
+    /// Vanilla `ServerEntity.sendChanges`. Non-player entities only.
+    pub fn send_changes(&self, world: &World) {
+        let entity = self.entity.get_entity();
+        self.send_bedrock_move(entity, world);
+        let tick = self.tick_count.fetch_add(1, Relaxed);
+        let needs_sync = entity.velocity_dirty.swap(false, Ordering::SeqCst);
+        if !(tick.is_multiple_of(self.update_interval.max(1))
+            || needs_sync
+            || entity.synched_data.is_dirty())
+        {
+            return;
+        }
+
+        let yaw = pack_degrees(entity.yaw.load());
+        let pitch = pack_degrees(entity.pitch.load());
+        let rot_changed = yaw != entity.last_sent_yaw.load(Relaxed)
+            || pitch != entity.last_sent_pitch.load(Relaxed);
+
+        if self.entity.is_passenger() {
+            if rot_changed {
+                self.send_move(entity, MoveSync::Rot, yaw, pitch, world);
+                entity.last_sent_yaw.store(yaw, Relaxed);
+                entity.last_sent_pitch.store(pitch, Relaxed);
+            }
+            entity.last_sent_pos.store(entity.pos.load());
+            entity.send_dirty_entity_data();
+            self.was_riding.store(true, Relaxed);
+        } else {
+            let pos = entity.pos.load();
+            let sync = self.pick_move(entity, pos, tick, rot_changed);
+            if needs_sync || self.track_deltas || entity.is_fall_flying() {
+                self.send_motion(entity, world);
+            }
+            if let Some(sync) = sync {
+                self.send_move(entity, sync, yaw, pitch, world);
+            }
+            entity.send_dirty_entity_data();
+            if let Some(sync) = sync {
+                if sync.sends_position() {
+                    entity.last_sent_pos.store(pos);
+                }
+                if sync.sends_rotation() {
+                    entity.last_sent_yaw.store(yaw, Relaxed);
+                    entity.last_sent_pitch.store(pitch, Relaxed);
+                }
+            }
+            self.was_riding.store(false, Relaxed);
+        }
+
+        let head_yaw = pack_degrees(entity.head_yaw.load());
+        if head_yaw != entity.last_sent_head_yaw.load(Relaxed) {
+            self.send_to_tracking_players(&CHeadRot::new(VarInt(self.entity_id), head_yaw), world);
+            entity.last_sent_head_yaw.store(head_yaw, Relaxed);
+        }
+    }
+
+    fn pick_move(
+        &self,
+        entity: &Entity,
+        pos: Vector3<f64>,
+        tick: u32,
+        rot_changed: bool,
+    ) -> Option<MoveSync> {
+        let teleport_delay = self.teleport_delay.fetch_add(1, Relaxed) + 1;
+        let base = entity.last_sent_pos.load();
+        let send_pos = (pos - base).length_squared() >= f64::from(7.629_394_5e-6f32)
+            || tick.is_multiple_of(60);
+        let delta = match (
+            i16::try_from(encode_pos(pos.x) - encode_pos(base.x)),
+            i16::try_from(encode_pos(pos.y) - encode_pos(base.y)),
+            i16::try_from(encode_pos(pos.z) - encode_pos(base.z)),
+        ) {
+            (Ok(x), Ok(y), Ok(z)) => Some(Vector3::new(x, y, z)),
+            _ => None,
+        };
+        let on_ground = entity.on_ground.load(Relaxed);
+        let is_arrow = [
+            &EntityType::ARROW,
+            &EntityType::SPECTRAL_ARROW,
+            &EntityType::TRIDENT,
+        ]
+        .contains(&entity.entity_type);
+
+        match delta {
+            Some(delta)
+                if teleport_delay <= 400
+                    && !self.was_riding.load(Relaxed)
+                    && self.was_on_ground.load(Relaxed) == on_ground =>
+            {
+                if (send_pos && rot_changed) || is_arrow {
+                    Some(MoveSync::PosRot(delta))
+                } else if send_pos {
+                    Some(MoveSync::Pos(delta))
+                } else if rot_changed {
+                    Some(MoveSync::Rot)
+                } else {
+                    None
+                }
+            }
+            _ => {
+                self.was_on_ground.store(on_ground, Relaxed);
+                self.teleport_delay.store(0, Relaxed);
+                Some(MoveSync::Absolute)
+            }
+        }
+    }
+
+    fn send_motion(&self, entity: &Entity, world: &World) {
+        let velocity = entity.velocity.load();
+        let diff = (velocity - entity.last_sent_velocity.load()).length_squared();
+        if diff > 1.0e-7 || (diff > 0.0 && velocity.length_squared() == 0.0) {
+            entity.last_sent_velocity.store(velocity);
+            self.send_to_tracking_players_editioned(
+                &CEntityVelocity::new(VarInt(self.entity_id), velocity),
+                &CSetActorMotion {
+                    target_runtime_id: VarULong(self.entity_id as u64),
+                    motion: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
+                    tick: VarULong(0),
+                },
+                world,
+            );
+        }
+    }
+
+    /// Java only -> Bedrock uses [`Self::send_bedrock_move`].
+    fn send_move(&self, entity: &Entity, sync: MoveSync, yaw: u8, pitch: u8, world: &World) {
+        let on_ground = entity.on_ground.load(Relaxed);
+        let id = VarInt(self.entity_id);
+        match sync {
+            MoveSync::Pos(delta) => {
+                self.send_to_tracking_players(&CUpdateEntityPos::new(id, delta, on_ground), world);
+            }
+            MoveSync::Rot => {
+                self.send_to_tracking_players(
+                    &CUpdateEntityRot::new(id, yaw, pitch, on_ground),
+                    world,
+                );
+            }
+            MoveSync::PosRot(delta) => self.send_to_tracking_players(
+                &CUpdateEntityPosRot::new(id, delta, yaw, pitch, on_ground),
+                world,
+            ),
+            MoveSync::Absolute => self.send_to_tracking_players(
+                &CEntityPositionSync::new(
+                    id,
+                    entity.pos.load(),
+                    entity.velocity.load(),
+                    entity.yaw.load(),
+                    entity.pitch.load(),
+                    on_ground,
+                ),
+                world,
+            ),
+        }
+    }
+
+    /// Bedrock -> every tick, only changed fields.
+    fn send_bedrock_move(&self, entity: &Entity, world: &World) {
+        let pos = self.entity.bedrock_pos();
+        let rot = [
+            pack_degrees(entity.pitch.load()),
+            pack_degrees(entity.yaw.load()),
+            pack_degrees(entity.head_yaw.load()),
+        ];
+        let last_pos = self.bedrock_pos.load();
+        let last_rot = self.bedrock_rot.load();
+
+        let mut flags = 0;
+        if !self.entity.is_passenger() {
+            for (now, last, flag) in [
+                (pos.x, last_pos.x, MOVE_ACTOR_DELTA_FLAG_HAS_X),
+                (pos.y, last_pos.y, MOVE_ACTOR_DELTA_FLAG_HAS_Y),
+                (pos.z, last_pos.z, MOVE_ACTOR_DELTA_FLAG_HAS_Z),
+            ] {
+                if (now as f32).to_bits() != (last as f32).to_bits() {
+                    flags |= flag;
+                }
+            }
+        }
+        for (i, flag) in [
+            MOVE_ACTOR_DELTA_FLAG_HAS_PITCH,
+            MOVE_ACTOR_DELTA_FLAG_HAS_YAW,
+            MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if rot[i] != last_rot[i] {
+                flags |= flag;
+            }
+        }
+        if flags == 0 {
+            return;
+        }
+
+        if flags
+            & (MOVE_ACTOR_DELTA_FLAG_HAS_X
+                | MOVE_ACTOR_DELTA_FLAG_HAS_Y
+                | MOVE_ACTOR_DELTA_FLAG_HAS_Z)
+            != 0
+        {
+            self.bedrock_pos.store(pos);
+        }
+        self.bedrock_rot.store(rot);
+        if entity.on_ground.load(Relaxed) {
+            flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
+        }
+        self.send_to_tracking_players_bedrock(
+            &CMoveActorDelta::new(
+                VarULong(self.entity_id as u64),
+                flags,
+                pos.x as f32,
+                pos.y as f32,
+                pos.z as f32,
+                rot[0],
+                rot[1],
+                rot[2],
+            ),
+            world,
+        );
     }
 
     fn collect_indirect_passengers(
@@ -605,7 +896,9 @@ impl EntityTracker {
 
         for entry in &self.entity_map {
             let tracked = entry.value();
-            if tracked.entity.get_entity().synched_data.is_dirty() {
+            if tracked.entity.get_player().is_none() {
+                tracked.send_changes(world);
+            } else if tracked.entity.get_entity().synched_data.is_dirty() {
                 tracked.entity.get_entity().send_dirty_entity_data();
             }
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -3240,65 +3240,9 @@ impl World {
             .iter()
             .filter(|p| p.gameprofile.id != gameprofile.id)
         {
-            let ex_profile = &existing_player.gameprofile;
-            let ex_entity = &existing_player.get_entity();
-            let ex_pos = ex_entity.pos.load();
-            let ex_vel = ex_entity.velocity.load();
-
-            let ex_player_list = CPlayerList {
-                action: CPlayerList::ACTION_ADD,
-                entries: vec![PlayerListEntry {
-                    uuid: ex_profile.id,
-                    entity_unique_id: VarLong(existing_player.entity_id() as i64),
-                    username: ex_profile.name.clone(),
-                    xuid: String::new(),
-                    platform_chat_id: String::new(),
-                    build_platform: BuildPlatform::Unknown,
-                    skin: (**existing_player.bedrock_skin.load()).clone(),
-                    is_teacher: false,
-                    is_host: false,
-                    is_sub_client: false,
-                    player_color: [0, 0, 0, 0],
-                }],
-            };
+            let (ex_player_list, ex_add_player) = existing_player.bedrock_spawn_packets();
             // Send PlayerList FIRST
             client.send_packet(&ex_player_list).await;
-
-            let ex_add_player = CAddPlayer {
-                uuid: ex_profile.id,
-                player_name: ex_profile.name.clone(),
-                target_runtime_id: VarULong(existing_player.entity_id() as u64),
-                platform_chat_id: String::new(),
-                position: Vector3::new(ex_pos.x as f32, ex_pos.y as f32, ex_pos.z as f32),
-                velocity: Vector3::new(ex_vel.x as f32, ex_vel.y as f32, ex_vel.z as f32),
-                rotation: Vector2::new(ex_entity.pitch.load(), ex_entity.yaw.load()),
-                y_head_rotation: ex_entity.head_yaw.load(),
-                carried_item: NetworkItemStackDescriptor::default(),
-                player_game_type: existing_player.gamemode.load().into(),
-                entity_data: ex_entity.bedrock_metadata(),
-                synced_properties: PropertySyncData::default(),
-                abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                    target_player_raw_id: existing_player.entity_id() as i64,
-                    player_permissions:
-                        pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                    command_permissions:
-                        pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                    layers: vec![
-                        pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                            serialized_layer: 0,
-                            abilities_set: 0,
-                            ability_value: 0,
-                            fly_speed: 0.05,
-                            vertical_fly_speed: 0.05,
-                            walk_speed: 0.1,
-                        },
-                    ],
-                },
-                actor_links: Vec::new(),
-                device_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-            };
-
             client.send_packet(&ex_add_player).await;
 
             let ex_held_item = existing_player.inventory().held_item();
@@ -3738,61 +3682,7 @@ impl World {
             let entity = &existing_player.get_entity();
             let pos = entity.pos.load();
             let gameprofile = &existing_player.gameprofile;
-            let bedrock_add_player = CAddPlayer {
-                uuid: gameprofile.id,
-                player_name: gameprofile.name.clone(),
-                target_runtime_id: VarULong(existing_player.entity_id() as u64),
-                platform_chat_id: String::new(),
-                position: Vector3::new(pos.x as f32, pos.y as f32, pos.z as f32),
-                velocity: Vector3::new(
-                    entity.velocity.load().x as f32,
-                    entity.velocity.load().y as f32,
-                    entity.velocity.load().z as f32,
-                ),
-                rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
-                y_head_rotation: entity.head_yaw.load(),
-                carried_item: NetworkItemStackDescriptor::default(),
-                player_game_type: existing_player.gamemode.load().into(),
-                entity_data: entity.bedrock_metadata(),
-                synced_properties: PropertySyncData::default(),
-                abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                    target_player_raw_id: existing_player.entity_id() as i64,
-                    player_permissions:
-                        pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                    command_permissions:
-                        pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                    layers: vec![
-                        pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                            serialized_layer: 0,
-                            abilities_set: 0,
-                            ability_value: 0,
-                            fly_speed: 0.05,
-                            vertical_fly_speed: 0.05,
-                            walk_speed: 0.1,
-                        },
-                    ],
-                },
-                actor_links: Vec::new(),
-                device_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-            };
-
-            let bedrock_player_list = CPlayerList {
-                action: CPlayerList::ACTION_ADD,
-                entries: vec![PlayerListEntry {
-                    uuid: gameprofile.id,
-                    entity_unique_id: VarLong(existing_player.entity_id() as i64),
-                    username: gameprofile.name.clone(),
-                    xuid: String::new(),
-                    platform_chat_id: String::new(),
-                    build_platform: BuildPlatform::Unknown,
-                    skin: (**existing_player.bedrock_skin.load()).clone(),
-                    is_teacher: false,
-                    is_host: false,
-                    is_sub_client: false,
-                    player_color: [0, 0, 0, 0],
-                }],
-            };
+            let (bedrock_player_list, bedrock_add_player) = existing_player.bedrock_spawn_packets();
 
             let actions = [
                 PlayerAction::AddPlayer {
@@ -4236,60 +4126,8 @@ impl World {
             return;
         }
 
-        let entity = subject.get_entity();
-        let entity_id = subject.entity_id();
-        let position = entity.pos.load();
-        let velocity = entity.velocity.load();
-        let player_list = CPlayerList {
-            action: CPlayerList::ACTION_ADD,
-            entries: vec![PlayerListEntry {
-                uuid: subject.gameprofile.id,
-                entity_unique_id: VarLong(entity_id.into()),
-                username: subject.gameprofile.name.clone(),
-                xuid: String::new(),
-                platform_chat_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-                skin: (**subject.bedrock_skin.load()).clone(),
-                is_teacher: false,
-                is_host: false,
-                is_sub_client: false,
-                player_color: [0; 4],
-            }],
-        };
-        let add_player = CAddPlayer {
-            uuid: subject.gameprofile.id,
-            player_name: subject.gameprofile.name.clone(),
-            target_runtime_id: VarULong(entity_id as u64),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
-            y_head_rotation: entity.head_yaw.load(),
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: subject.gamemode.load().into(),
-            entity_data: entity.bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: entity_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
-        let remove = CRemoveActor::new(VarLong(entity_id.into()));
+        let (player_list, add_player) = subject.bedrock_spawn_packets();
+        let remove = CRemoveActor::new(VarLong(subject.entity_id().into()));
 
         for recipient in self.players.load().iter() {
             if let ClientPlatform::Bedrock(client) = recipient.client.as_ref() {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -40,7 +40,12 @@ use crate::{
         {OnNeighborUpdateArgs, OnScheduledTickArgs},
     },
     command::client_suggestions,
-    entity::{Entity, EntityBase, RemovalReason, player::Player, r#type::from_type},
+    entity::{
+        Entity, EntityBase, RemovalReason,
+        boss::ender_dragon::{EnderDragonEntity, EnderDragonPart},
+        player::Player,
+        r#type::from_type,
+    },
     error::PumpkinError,
     net::{ClientPlatform, bedrock::BedrockClient, java::JavaClient},
     plugin::{
@@ -256,6 +261,9 @@ pub struct World {
     /// A map of active entities within the world, keyed by their unique UUID.
     /// This does not include players.
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
+    /// Ender dragon hitboxes, keyed by entity id. They are addressable but never
+    /// ticked, saved or tracked
+    pub dragon_parts: DashMap<i32, Arc<EnderDragonPart>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: std::sync::Mutex<Scoreboard>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
@@ -417,6 +425,7 @@ impl World {
             active_chunk_tracker: std::sync::Mutex::new(ActiveChunkTracker::default()),
             forced_chunks: std::sync::Mutex::new(FxHashSet::default()),
             server,
+            dragon_parts: DashMap::new(),
             block_entities: DashMap::new(),
             pending_block_entity_migrations: crossbeam::queue::SegQueue::new(),
             custom_data: std::sync::Mutex::new(custom_data),
@@ -4513,7 +4522,28 @@ impl World {
                 return Some(player.clone() as Arc<dyn EntityBase>);
             }
         }
-        None
+        // Vanilla `getEntityOrPart`: the client attacks dragon parts by id.
+        self.dragon_parts
+            .get(&id)
+            .map(|part| part.clone() as Arc<dyn EntityBase>)
+    }
+
+    /// Vanilla `onTrackingStart`: parts are addressable by id, but never tracked.
+    fn add_dragon_parts(&self, entity: &dyn EntityBase) {
+        if let Some(dragon) = entity.cast_any().downcast_ref::<EnderDragonEntity>() {
+            for part in &dragon.parts {
+                self.dragon_parts
+                    .insert(part.entity.entity_id, part.clone());
+            }
+        }
+    }
+
+    /// Vanilla `onTrackingEnd`. Keyed by uuid, removal also comes in as a bare `Entity`.
+    fn remove_dragon_parts(&self, entity: &Entity) {
+        if entity.entity_type == &EntityType::ENDER_DRAGON {
+            self.dragon_parts
+                .retain(|_, part| part.dragon_uuid != entity.entity_uuid);
+        }
     }
 
     /// Gets a `Player` by a username
@@ -4545,12 +4575,20 @@ impl World {
 
     // Gets all non Player entities at a Box
     pub fn get_entities_at_box(&self, aabb: &BoundingBox) -> Vec<Arc<dyn EntityBase>> {
-        self.entities
+        let mut found: Vec<Arc<dyn EntityBase>> = self
+            .entities
             .load()
             .iter()
             .filter(|entity| entity.get_entity().bounding_box.load().intersects(aabb))
             .cloned()
-            .collect()
+            .collect();
+        // Vanilla `Level.getEntities` merges the dragon parts in.
+        for part in &self.dragon_parts {
+            if part.entity.bounding_box.load().intersects(aabb) {
+                found.push(part.value().clone() as Arc<dyn EntityBase>);
+            }
+        }
+        found
     }
 
     // Gets all Player entities at a Box
@@ -4910,6 +4948,7 @@ impl World {
     pub fn spawn_entity_non_save(&self, entity: Arc<dyn EntityBase>) {
         let _base_entity = entity.get_entity();
         self.entity_tracker.add_entity(&entity, self);
+        self.add_dragon_parts(entity.as_ref());
         self.spawn_state.load().add_entity(self, entity.as_ref());
 
         self.entities.rcu(|current_entities| {
@@ -4958,6 +4997,7 @@ impl World {
         // serialized at once (which would double it on the next reload).
         self.spawn_state.load().add_entity(self, entity.as_ref());
         self.entity_tracker.add_entity(&entity, self);
+        self.add_dragon_parts(entity.as_ref());
 
         self.entities.rcu(|current_entities| {
             let mut new_entities = (**current_entities).clone();
@@ -4979,6 +5019,7 @@ impl World {
 
         self.spawn_state.load().remove_entity(self, entity);
         self.entity_tracker.remove_entity(entity, self);
+        self.remove_dragon_parts(base_entity);
         self.entities.rcu(|current_entities| {
             let mut new_entities = (**current_entities).clone();
             new_entities.retain(|e| e.get_entity().entity_uuid != base_entity.entity_uuid);
@@ -5013,6 +5054,7 @@ impl World {
 
         for entity in entities_to_remove {
             self.entity_tracker.remove_entity(entity.as_ref(), self);
+            self.remove_dragon_parts(entity.get_entity());
             self.save_entity(&entity).await;
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -4691,8 +4691,6 @@ impl World {
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner),
                     );
-                    let mut entities_to_add: Vec<Arc<dyn EntityBase>> =
-                        Vec::with_capacity(entity_nbts.len());
                     for entity_nbt in &entity_nbts {
                         let Some(id) = entity_nbt.get_string("id") else {
                             debug!("Entity has no ID");
@@ -4721,30 +4719,11 @@ impl World {
                         // stale data.
                         base_entity.velocity.store(Vector3::default());
 
-                        player.client.enqueue_spawn_packet(&entity);
-                        player.try_restore_vehicle(&entity);
-                        entities_to_add.push(entity);
-                    }
-
-                    if !entities_to_add.is_empty() {
-                        world.entities.rcu(|current_entities| {
-                            let mut new_entities = (**current_entities).clone();
-                            new_entities.extend(entities_to_add.iter().cloned());
-                            new_entities
-                        });
-                    }
-                } else {
-                    // The chunk's entities are already live (another watcher loaded
-                    // them). Just send this player the spawn packets for the live
-                    // entities currently in this chunk.
-                    for entity in world.entities.load().iter() {
-                        let base_entity = entity.get_entity();
-                        if base_entity.chunk_pos.load() == position {
-                            player.client.enqueue_spawn_packet(entity);
-                            player.try_restore_vehicle(entity);
-                        }
+                        // Tracker owns pairing: spawn packets for every watcher.
+                        world.add_entity_silent(entity);
                     }
                 }
+                // Already-live chunk: tracker pairs on its next pass.
             }
 
             #[cfg(debug_assertions)]
@@ -5196,21 +5175,6 @@ impl World {
 
         entity.init_data_tracker();
         self.add_entity_silent(entity);
-    }
-
-    pub fn broadcast_entity_spawn(&self, entity: &Arc<dyn EntityBase>) {
-        let base_entity = entity.get_entity();
-        let chunk_pos = base_entity.chunk_pos.load();
-
-        let players = self.players.load();
-        for player in players.iter() {
-            let center = player.get_entity().chunk_pos.load();
-            let view_distance = get_view_distance(player).get() as i32;
-
-            if is_within_view_distance(chunk_pos, center, view_distance) {
-                player.client.try_enqueue_spawn_packet(entity);
-            }
-        }
     }
 
     #[expect(clippy::needless_pass_by_value)]

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -5,7 +5,7 @@ use pumpkin_data::item::{BedrockItem, BedrockItemVersion};
 use pumpkin_protocol::bedrock::client::item_registry::{CItemRegistry, ItemData};
 use pumpkin_protocol::bedrock::client::level_event::{CLevelEvent, LevelEvent};
 use pumpkin_protocol::bedrock::client::{CBiomeDefinitionList, block_actor_data::CBlockActorData};
-use pumpkin_protocol::bedrock::network_item::{NetworkItemDescriptor, NetworkItemStackDescriptor};
+use pumpkin_protocol::bedrock::network_item::NetworkItemDescriptor;
 use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use pumpkin_world::generation::proto_chunk::GenerationCache;
 use rayon::prelude::*;
@@ -103,7 +103,6 @@ use pumpkin_protocol::{
     BClientPacket, ClientPacket, IdOr, SoundEvent,
     bedrock::{
         client::{
-            add_player::CAddPlayer,
             block_event::CBlockEvent as CBedrockBlockEvent,
             common::BuildPlatform,
             creative_content::{
@@ -3171,41 +3170,8 @@ impl World {
             &bedrock_player_list,
         );
 
-        let bedrock_add_player = CAddPlayer {
-            uuid: gameprofile.id,
-            player_name: gameprofile.name.clone(),
-            target_runtime_id: VarULong(runtime_id),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(pitch, yaw),
-            y_head_rotation: yaw,
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: player.gamemode.load().into(),
-            entity_data: entity.bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: runtime_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
-
-        self.broadcast_packet_except_editioned(
+        // Bedrock gets `AddPlayer` from the tracker.
+        self.broadcast_packet_except(
             &[gameprofile.id],
             &CSpawnEntity::new(
                 (runtime_id as i32).into(),
@@ -3218,7 +3184,6 @@ impl World {
                 0.into(),
                 velocity,
             ),
-            &bedrock_add_player,
         );
 
         self.send_player_equipment(&player);
@@ -3240,23 +3205,12 @@ impl World {
             .iter()
             .filter(|p| p.gameprofile.id != gameprofile.id)
         {
-            let (ex_player_list, ex_add_player) = existing_player.bedrock_spawn_packets();
-            // Send PlayerList FIRST
-            client.send_packet(&ex_player_list).await;
-            client.send_packet(&ex_add_player).await;
-
-            let ex_held_item = existing_player.inventory().held_item();
-
-            let ex_be_mob_equipment = pumpkin_protocol::bedrock::client::CMobEquipment {
-                target_runtime_id: (existing_player.entity_id() as u64).into(),
-                item: (&ex_held_item).into(),
-                slot: 0,
-                selected_slot: 0,
-                container_id: 0,
-            };
-
-            client.send_packet(&ex_be_mob_equipment).await;
+            client
+                .send_packet(&existing_player.bedrock_player_list())
+                .await;
         }
+        // Actors come from the tracker, in range only.
+        self.pair_new_player_with_tracked_entities(&player);
 
         player.has_played_before.store(true, Ordering::Relaxed);
 
@@ -3600,41 +3554,8 @@ impl World {
 
         let gameprofile = &player.gameprofile;
 
-        let bedrock_add_player = CAddPlayer {
-            uuid: gameprofile.id,
-            player_name: gameprofile.name.clone(),
-            target_runtime_id: VarULong(entity_id as u64),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(pitch, yaw),
-            y_head_rotation: yaw,
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: player.gamemode.load().into(),
-            entity_data: player.get_entity().bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: entity_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
-
-        // Spawn the player for every client.
+        // Spawn the player for every Java client
+        // Bedrock gets `AddPlayer` from the tracker.
         let spawn_entity = CSpawnEntity::new(
             entity_id.into(),
             gameprofile.id,
@@ -3647,11 +3568,7 @@ impl World {
             velocity,
         );
 
-        self.broadcast_packet_except_editioned(
-            &[player.gameprofile.id],
-            &spawn_entity,
-            &bedrock_add_player,
-        );
+        self.broadcast_packet_except(&[player.gameprofile.id], &spawn_entity);
 
         // Broadcast metadata to Java players so they can correctly interact with the new player
         let skin_parts = player.config.load().skin_parts;
@@ -4129,8 +4046,13 @@ impl World {
         let (player_list, add_player) = subject.bedrock_spawn_packets();
         let remove = CRemoveActor::new(VarLong(subject.entity_id().into()));
 
+        let Some(tracked) = self.entity_tracker.get_tracked_entity(subject.entity_id()) else {
+            return;
+        };
         for recipient in self.players.load().iter() {
-            if let ClientPlatform::Bedrock(client) = recipient.client.as_ref() {
+            if tracked.seen_by.contains(&recipient.gameprofile.id)
+                && let ClientPlatform::Bedrock(client) = recipient.client.as_ref()
+            {
                 client.send_packet(&remove).await;
                 client.send_packet(&player_list).await;
                 client.send_packet(&add_player).await;


### PR DESCRIPTION
## Description

The Ender Dragon hitbox was flagged as wrong by coderabbit in this PR: https://github.com/Pumpkin-MC/Pumpkin/pull/3401#issuecomment-5639131136 This is a Follow up to that issue and is based on it, it should be merged after that PR.

I encoutered multiple disconects with the boss bar that where adressesd.
The Dragon had problems with the hitbox, but this is only partly due to the doubled body parts, the player hitbox has the enlaged state for mobs, not only pickup.
Now the dragon is actually killable again (by far not finished)

- Dragon parts registered and addressable by id and bounding box, without being ticked, saved or tracked.
- No self-despawn, so the fight no longer restarts
- Dragon and part ids reserved together -> they must be stiched together for the client, and a partial reservation let other entities take part ids.

## Testing

gametesting and cargo clippy --release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Ender Dragon hit detection and per-part damage behavior.
  * Bedrock players and entities now spawn and synchronize more reliably.
  * Falling blocks update nearby clients correctly when landing.
  * Boss bars remain synchronized during Ender Dragon fights and respawns.

* **Bug Fixes**
  * Reduced redundant entity movement and rotation updates.
  * Improved Bedrock chunk loading by excluding trailing empty sections.
  * Corrected item and entity positioning for Bedrock clients.
  * Improved entity tracking and movement synchronization across clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->