### PR TITLE
fix(mob): send vanilla POOF particles when the corpse despawns 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1824,6 +1824,10 @@ impl LivingEntity {
         }
     }
 
+    /// Marks the entity as dead exactly once and runs the server-side death
+    /// flow: stop movement input, attribute the kill, drop loot, broadcast the
+    /// `Death` (3) entity event, and hand out XP. Safe to call on every lethal
+    /// damage event; only the first call has an effect.
     pub fn on_death(
         &self,
         damage_type: DamageType,

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3104,6 +3104,10 @@ impl EntityBase for LivingEntity {
         self.get_attribute_value(&Attributes::GRAVITY)
     }
 
+    /// Advances the living entity by one tick: base entity tick, movement and
+    /// physics while alive (still applied during the 20-tick death animation so
+    /// knockback lands), velocity coalescing, status effects, void damage, and
+    /// death-animation completion.
     #[allow(clippy::too_many_lines)]
     fn tick(&self, caller: &dyn EntityBase, server: &Server) {
         self.entity.tick(caller, server);
@@ -3356,14 +3360,15 @@ impl EntityBase for LivingEntity {
                 // respawn. Removing one here breaks reconnecting while dead.
                 return;
             }
-            // Only send death particles once (on the exact tick death_time reaches 20)
-            // and then remove the entity, preventing entity_event spam.
-            if time == 20 && !self.entity.removed.swap(true, Ordering::Relaxed) {
-                self.entity.world.load().send_entity_status(
-                    &self.entity,
-                    EntityStatus::Death,
-                    Some(ActorEventID::Death),
-                );
+            // Vanilla `LivingEntity.tickDeath` sends the POOF (60) particle event
+            // once the death animation finished; the death event (3) was already
+            // broadcast in `on_death`. Sending it again here would restart the
+            // client-side death animation.
+            if time >= 20 && !self.entity.removed.swap(true, Ordering::Relaxed) {
+                self.entity
+                    .world
+                    .load()
+                    .send_entity_status(&self.entity, EntityStatus::Poof, None);
                 self.entity.remove();
             }
         }

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1780,6 +1780,10 @@ impl LivingEntity {
     }
 
     #[allow(clippy::redundant_closure_for_method_calls)]
+    /// Builds the chat death message for this entity: picks the
+    /// `death.attack.<id>` (or the `.player` variant when a killer entity is
+    /// known, or the kill-credit name when the killer is offline/removed)
+    /// translation and fills in the victim and killer display names.
     pub fn get_death_message(
         dyn_self: &dyn EntityBase,
         damage_type: DamageType,

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -6904,6 +6904,11 @@ impl World {
         self.ray_trace_entities(start, end).into_iter().next()
     }
 
+    /// Traces the block grid from `start_pos` to `end_pos` (vanilla
+    /// `Block.clip` semantics) and returns the first block for which
+    /// `hit_check` returns true, together with the face direction the ray
+    /// entered it. The start block is tested like any other; returns `None`
+    /// when the ray hits nothing or starts and ends in the same block.
     pub fn raycast(
         self: &Arc<Self>,
         start_pos: Vector3<f64>,

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -6896,6 +6896,8 @@ impl World {
             .collect()
     }
 
+    /// Returns the closest entity the segment from `start` to `end` hits, or
+    /// `None`. Convenience wrapper over [`Self::ray_trace_entities`].
     pub fn ray_trace_entity(
         &self,
         start: Vector3<f64>,
@@ -6905,10 +6907,13 @@ impl World {
     }
 
     /// Traces the block grid from `start_pos` to `end_pos` (vanilla
-    /// `Block.clip` semantics) and returns the first block for which
-    /// `hit_check` returns true, together with the face direction the ray
-    /// entered it. The start block is tested like any other; returns `None`
-    /// when the ray hits nothing or starts and ends in the same block.
+    /// `Block.clip` semantics) and returns the first block the ray actually
+    /// passes through whose outline collides and whose `hit_check` returns
+    /// true, together with the direction reported for that hit. The start
+    /// block is tested like any other; since the ray begins inside it, the
+    /// reported direction there is a fallback rather than a true entry face.
+    /// Returns `None` when nothing is hit or the ray starts and ends in the
+    /// same block.
     pub fn raycast(
         self: &Arc<Self>,
         start_pos: Vector3<f64>,


### PR DESCRIPTION
## What
When a mob's death animation finished (death_time >= 20), the corpse removal re-sent the `Death` (3) entity status. Vanilla `LivingEntity.tickDeath` sends the **POOF (60)** particle event exactly once at that moment; the death event (3) was already broadcast in `die()`/`on_death`. This PR sends `EntityStatus::Poof` instead, and uses `time >= 20` (with the existing `removed` CAS guard) so removal can never be missed.

## Why
Re-sending the death (3) status at corpse removal makes clients replay the fall-over death animation for an entity that is about to despawn. Vanilla only ever sends the POOF smoke puff there. Verified against a vanilla-matching headless protocol-776 client: with this change the client receives a single entity_event 60 and no duplicate death animation.

## Scope note (rebase)
This PR originally also applied the raycast origin-block `hit_check` fix that restored mob line-of-sight targeting (#3332 / #2537). That portion was independently fixed and merged via #3174, so the conflicting hunk was dropped in this rebase — what remains is the death-particle half. The bug was found while investigating #3332 with a reproducible headless client (bots + notes available in my fork workspace).

## Impact
- Corpse removal now matches vanilla: one POOF event, no death-animation replay.
- No API or protocol changes; behavior-only fix in the death tick path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed entity death animations restarting instead of completing properly.
  - Entities now reliably complete their death animation and produce the expected poof effect, including when completion is delayed.
  - Prevented duplicate death events during the final stage of the animation.
  - Death effects now occur after the full animation completes, improving consistency in entity removal visuals.

- **Documentation**
  - Added documentation describing entity death handling and world raycasting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->