### PR TITLE
fix(egg): keep the Pterodactyl allocation port in sync on every start

### DIFF
--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -141,6 +141,35 @@ impl LoadConfiguration for PumpkinConfig {
     }
 }
 
+/// Environment variable that overrides `networking.java.address` at startup.
+///
+/// Hosting panels such as Pterodactyl assign a port per server; this lets them pass
+/// the bind address on every start without having to rewrite `pumpkin.toml`.
+pub const JAVA_ADDRESS_ENV: &str = "PUMPKIN_JAVA_ADDRESS";
+
+impl PumpkinConfig {
+    /// Applies overrides from environment variables on top of the loaded configuration.
+    ///
+    /// Overrides only affect the running server and are never written back to `pumpkin.toml`.
+    pub fn apply_env_overrides(&mut self) {
+        let Ok(value) = std::env::var(JAVA_ADDRESS_ENV) else {
+            return;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            return;
+        }
+        let address: std::net::SocketAddr = match value.parse() {
+            Ok(address) => address,
+            Err(err) => {
+                warn!("Ignoring {JAVA_ADDRESS_ENV}={value:?}: {err}");
+                return;
+            }
+        };
+        self.advanced.networking.java.address = address;
+    }
+}
+
 /// Advanced configuration for optional and feature-specific server settings.
 ///
 /// Allows enabling/disabling features, customizing behaviour, and

--- a/crates/pumpkin-config/src/networking/java.rs
+++ b/crates/pumpkin-config/src/networking/java.rs
@@ -10,6 +10,8 @@ pub struct JavaConfig {
     /// Whether Java Edition Clients are Accepted.
     pub enabled: bool,
     /// The address and port to which the Java Edition server will bind.
+    ///
+    /// Can be overridden at startup with the `PUMPKIN_JAVA_ADDRESS` environment variable.
     pub address: SocketAddr,
     /// Whether packet encryption is enabled. Required when online mode is enabled.
     pub encryption: bool,

--- a/crates/pumpkin/src/main.rs
+++ b/crates/pumpkin/src/main.rs
@@ -67,11 +67,12 @@ async fn main() {
 
     let exec_dir = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
-    let config = PumpkinConfig::load(&exec_dir);
+    let mut config = PumpkinConfig::load(&exec_dir);
 
     let vanilla_data = VanillaData::load();
 
     pumpkin::init_logger(&config.advanced);
+    config.apply_env_overrides();
 
     info!(
         "{}",

--- a/egg-pumpkin.json
+++ b/egg-pumpkin.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-02-10T08:07:42+00:00",
+    "exported_at": "2026-09-10T00:00:00+00:00",
     "name": "Pumpkin",
     "author": "lilalexmed@proton.me",
     "description": "Pumpkin is a Minecraft server built entirely in Rust, offering a fast, efficient, and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.",
@@ -14,7 +14,7 @@
         "Debian": "ghcr.io\/pterodactyl\/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/pumpkin",
+    "startup": "PUMPKIN_JAVA_ADDRESS=0.0.0.0:{{SERVER_PORT}} .\/pumpkin",
     "config": {
         "files": "{\r\n    \"pumpkin.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"address = \\\"0.0.0.0:25565\\\"\": \"address = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server is now running.\"\r\n}",
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\nset -eux\r\n\r\napk add --no-cache curl jq\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$(uname -m)\r\ncase \"$ARCH\" in\r\n    x86_64|amd64)\r\n        PUMPKIN_ARCH=\"X64\"\r\n        ;;\r\n    aarch64|arm64)\r\n        PUMPKIN_ARCH=\"ARM64\"\r\n        ;;\r\n    *)\r\n        echo \"Unsupported architecture: $ARCH\"\r\n        exit 1\r\n        ;;\r\nesac\r\n\r\nBINARY_NAME=\"pumpkin-${PUMPKIN_ARCH}-Linux-musl\"\r\n\r\nif [ -n \"${DOWNLOAD_URL:-}\" ]; then\r\n    URL=\"$DOWNLOAD_URL\"\r\nelif [ \"${VERSION:-nightly}\" = \"latest\" ] || [ \"${VERSION:-nightly}\" = \"nightly\" ]; then\r\n    URL=\"https:\/\/github.com\/${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\/releases\/download\/nightly\/${BINARY_NAME}\"\r\nelse\r\n    URL=\"https:\/\/github.com\/${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\/releases\/download\/${VERSION}\/${BINARY_NAME}\"\r\nfi\r\n\r\necho \"Downloading Pumpkin from: $URL\"\r\ncurl -fsSL \"$URL\" -o \/mnt\/server\/pumpkin\r\nchmod +x \/mnt\/server\/pumpkin\r\n\r\n# Quickly start and kill server to generate initial configuration if not present\r\nif [ ! -f \/mnt\/server\/pumpkin.toml ]; then\r\n    timeout 2 .\/pumpkin || true\r\nfi",
+            "script": "#!\/bin\/ash\r\nset -eux\r\n\r\napk add --no-cache curl\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$(uname -m)\r\ncase \"$ARCH\" in\r\n    x86_64|amd64)\r\n        PUMPKIN_ARCH=\"X64\"\r\n        ;;\r\n    aarch64|arm64)\r\n        PUMPKIN_ARCH=\"ARM64\"\r\n        ;;\r\n    *)\r\n        echo \"Unsupported architecture: $ARCH\"\r\n        exit 1\r\n        ;;\r\nesac\r\n\r\nBINARY_NAME=\"pumpkin-${PUMPKIN_ARCH}-Linux-musl\"\r\nREPO=\"${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\"\r\n\r\nif [ -n \"${DOWNLOAD_URL:-}\" ]; then\r\n    URL=\"$DOWNLOAD_URL\"\r\nelif [ \"${VERSION:-nightly}\" = \"nightly\" ]; then\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/download\/nightly\/${BINARY_NAME}\"\r\nelif [ \"$VERSION\" = \"latest\" ]; then\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/latest\/download\/${BINARY_NAME}\"\r\nelse\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/download\/${VERSION}\/${BINARY_NAME}\"\r\nfi\r\n\r\necho \"Downloading Pumpkin from: $URL\"\r\n# Download to a temporary file so a failed download never replaces a working binary.\r\ncurl -fsSL --retry 3 \"$URL\" -o pumpkin.download\r\nmv -f pumpkin.download pumpkin\r\nchmod +x pumpkin\r\n\r\n# Seed a minimal config so the panel can write the allocated port on the first start.\r\n# Pumpkin fills in every other setting with its defaults when it starts.\r\nif [ ! -f pumpkin.toml ]; then\r\n    printf '[networking.java]\\naddress = \"0.0.0.0:25565\"\\n' > pumpkin.toml\r\nfi",
             "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }
@@ -41,7 +41,7 @@
         },
         {
             "name": "Pumpkin Version",
-            "description": "The version of Pumpkin to install. Options: 'nightly', 'latest', or a specific release tag (e.g. 'v0.1.0').\r\nScope: installation",
+            "description": "The version of Pumpkin to install: 'nightly' (newest development build), 'latest' (newest stable release) or a specific release tag (e.g. 'v0.1.0').\r\nScope: installation",
             "env_variable": "VERSION",
             "default_value": "nightly",
             "user_viewable": true,


### PR DESCRIPTION
Split out of #3398 as requested.

Pterodactyl's `file` config parser matches a line prefix and replaces the whole line. The find key `address = "0.0.0.0:25565"` therefore only matches on the first boot; after that the line holds the allocated port, so a changed allocation is never applied again. A shorter prefix (`address = `) can't be used either, because the RCON, Bedrock and query lines start the same way, and there is no TOML parser in the panel. The yolks entrypoint runs `exec env ${PARSED}` without a shell, so the startup command can't rewrite the file either.

- `PUMPKIN_JAVA_ADDRESS` overrides `networking.java.address` at startup. It is applied after the logger is up and never written back to `pumpkin.toml`; an invalid value is logged and ignored.
- The egg's startup command passes the allocated port through that variable.
- `VERSION=latest` now resolves to `releases/latest` instead of the nightly tag.
- The installer downloads to a temporary file with `--retry 3`, so a failed download can't replace a working binary, and seeds a minimal `pumpkin.toml` instead of briefly starting the server. Unused `jq` dropped.

The existing `file` parser entry stays, so older binaries still get the right port on the first boot.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin-config` passes. The egg JSON is valid, the install script round-trips and passes `sh -n`. I checked the wings `file` parser and the yolks entrypoint against their sources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Java networking address can now be overridden at startup with the `PUMPKIN_JAVA_ADDRESS` environment variable.
  - Pterodactyl deployments now bind the Java address to the allocated server port.
  - Installation supports the `latest` release tag.

- **Bug Fixes**
  - Invalid or empty Java address overrides are safely ignored.
  - Server downloads now retry failures and use safer temporary-file handling.

- **Documentation**
  - Added guidance for configuring the Java address through the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->