### PR TITLE
fix(block): grow huge mushrooms from bone meal again

### DIFF
--- a/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
@@ -98,6 +98,10 @@ impl MushroomPlantBlock {
             for dx in -radius..=radius {
                 for dz in -radius..=radius {
                     let check_pos = pos.add(dx, dy, dz);
+                    // The mushroom itself is only replaced with air after this check.
+                    if check_pos == *pos {
+                        continue;
+                    }
                     if !world.is_loaded(&check_pos) {
                         return false;
                     }


### PR DESCRIPTION
Split out of #3398 as requested.

Bone meal never grows a huge mushroom. `grow_mushroom` checks whether the space is free before it replaces the mushroom with air, and the loop starts at the mushroom's own position, which is neither air nor leaves, so the check always fails. Vanilla removes the block first (`MushroomBlock.growMushroom` calls `removeBlock` before placing the feature).

The check now skips the mushroom's own position.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed mushroom growth validation so the source mushroom’s position is excluded when checking target positions.
  - Mushroom structures can now grow correctly when the source position would otherwise interfere with placement validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->