### PR TITLE
fix(brewing): follow screen slot rules and fire the start event

### DIFF
--- a/crates/pumpkin/src/block/entities/brewing_stand.rs
+++ b/crates/pumpkin/src/block/entities/brewing_stand.rs
@@ -12,6 +12,7 @@ use pumpkin_data::potion::Potion;
 use pumpkin_data::potion_brewing::BREWING_RECIPES;
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::tag::{self, Taggable};
+use pumpkin_inventory::brewing::brewing_screen_handler::{is_fuel, is_ingredient, is_potion_item};
 use pumpkin_inventory::{Inventory, sync_read_items_from_nbt, sync_write_items_to_nbt};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::codec::recipe::DynamicRecipe;
@@ -264,22 +265,8 @@ impl BrewingStandBlockEntity {
             }
         }
 
-        // Check if we can immediately start the next brew
-        if let Ok(items) = self.items.read() {
-            let ingredient = items[3].clone();
-            drop(items);
-            if self.fuel.load(Ordering::Relaxed) > 0 && self.is_brewable(&ingredient, world) {
-                self.fuel.fetch_sub(1, Ordering::Relaxed);
-                self.brew_time.store(400, Ordering::Relaxed);
-                *self
-                    .ingredient_item
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                    Some(ingredient.get_item());
-            } else {
-                self.brew_time.store(0, Ordering::Relaxed);
-            }
-        }
+        // Like vanilla, the next brew is started by `tick` so it goes through `BrewingStartEvent`.
+        self.brew_time.store(0, Ordering::Relaxed);
 
         // Play sound at the center of the block
         let pos = Vector3::new(
@@ -418,19 +405,18 @@ impl pumpkin_inventory::Inventory for BrewingStandBlockEntity {
         }
 
         match slot {
-            // Slots 0-2 - potion bottles
-            0..=2 => stack
-                .get_data_component::<pumpkin_data::data_component_impl::PotionContentsImpl>()
-                .is_some(),
-            // Slot 3 - ingredient (must be tagged as brewable)
-            3 => {
-                // Check if item is a valid brewing ingredient
-                if stack.get_item().has_tag(&tag::Item::MINECRAFT_BREWING_FUEL) {
-                    return false; // Fuel should not go in ingredient slot
-                }
-                // Allow any item that's not fuel (ingredient validation happens during brewing)
-                true
+            // Slots 0-2 - potion bottles, one per slot
+            0..=2 => {
+                is_potion_item(stack.get_item())
+                    && self
+                        .items
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)[slot]
+                        .is_empty()
             }
+            // Slot 3 - ingredient. Fuel stays out because hoppers don't use vanilla's
+            // per-side slots yet and would otherwise fill the ingredient slot with it.
+            3 => !is_fuel(stack.get_item()) && is_ingredient(stack.get_item()),
             // Slot 4 - fuel
             4 => stack.get_item().has_tag(&tag::Item::MINECRAFT_BREWING_FUEL),
             _ => false,


### PR DESCRIPTION
Split out of #3398 as requested. Two brewing stand fixes.

**Hoppers can jam the stand.** `is_valid_slot_for` accepted any non-fuel item in the ingredient slot, so a hopper could fill it with cobblestone and block brewing, and it rejected glass bottles in the potion slots, which vanilla allows. The slots now follow the same rules as the brewing screen: real ingredients only, and potion items one per slot. Fuel stays out of the ingredient slot, because hoppers don't implement vanilla's per-side slots yet (`TODO check WorldlyContainer` in `block/entities/hopper.rs`).

**Chained brews skip `BrewingStartEvent`.** `do_brew` started the next brew itself: it took the fuel and set the timer. Vanilla lets the timer end at 0 and starts the next brew from `serverTick`. `do_brew` now leaves the timer at 0, so `tick` starts it through the normal path and the event fires for every brew.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin -p pumpkin-inventory` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Brewing stands now validate potion, ingredient, and fuel items more accurately when placing items in slots.
  * Brewing stands reliably begin the next brewing cycle through their normal update process after a brew completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->