### PR TITLE
fix(hopper): compare components when stacking items

### DIFF
--- a/crates/pumpkin/src/block/entities/hopper.rs
+++ b/crates/pumpkin/src/block/entities/hopper.rs
@@ -426,8 +426,9 @@ impl HopperBlockEntity {
                     dst = item.clone();
                     to.set_stack(j, dst);
                     success = true;
-                } else if dst.item_count < dst.get_max_stack_size() && dst.item == item.item {
-                    // TODO check Components equal
+                } else if dst.item_count < dst.get_max_stack_size()
+                    && dst.are_items_and_components_equal(item)
+                {
                     dst.item_count += 1;
                     to.set_stack(j, dst);
                     success = true;


### PR DESCRIPTION
Split out of #3398 as requested.

`HopperBlockEntity::add_one_item` merged stacks by item type only, with a `TODO check Components equal`. A hopper therefore merged a renamed or enchanted item into a plain stack of the same type and dropped its components. All three hopper transfer paths (pull from above, item pickup, push into the target) go through this function.

It now uses `ItemStack::are_items_and_components_equal`, the same check the extraction path got in #3147.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item stacking so items are combined only when both their item IDs and components match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->