### PR TITLE
fix(entity): keep armor stand name and let projectiles break it

### DIFF
--- a/crates/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/crates/pumpkin/src/entity/decoration/armor_stand.rs
@@ -5,7 +5,8 @@ use crossbeam::atomic::AtomicCell;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::{
     damage::DamageType,
-    data_component_impl::{EquipmentSlot, EquipmentType},
+    data_component::DataComponent,
+    data_component_impl::{CustomNameImpl, DataComponentImpl, EquipmentSlot, EquipmentType},
     entity::EntityStatus,
     item::Item,
     particle::Particle,
@@ -187,10 +188,14 @@ impl ArmorStandEntity {
 
     fn break_and_drop_items(&self) {
         let entity = self.get_entity();
-        //let name = entity.custom_name.unwrap_or(entity.get_name());
 
-        //TODO: i am stupid! let armor_stand_item = ItemStack::new_with_component(1, &Item::ARMOR_STAND, vec![(DataComponent::CustomName, self.get_custom_name())]);
-        let armor_stand_item = ItemStack::new(1, &Item::ARMOR_STAND);
+        let mut armor_stand_item = ItemStack::new(1, &Item::ARMOR_STAND);
+        if let Some(name) = &**entity.custom_name.load() {
+            armor_stand_item.patch.push((
+                DataComponent::CustomName,
+                Some(CustomNameImpl { name: name.clone() }.to_dyn()),
+            ));
+        }
         entity
             .world
             .load()
@@ -328,7 +333,12 @@ impl EntityBase for ArmorStandEntity {
             game_rules.mob_griefing
         };
 
-        if !mob_griefing_gamerule && source.is_some_and(|source| source.get_player().is_none()) {
+        // Like vanilla, only block damage caused by a mob (the shooter, not the projectile).
+        if !mob_griefing_gamerule
+            && cause
+                .or(source)
+                .is_some_and(|attacker| attacker.get_mob().is_some())
+        {
             return false;
         }
 


### PR DESCRIPTION
Split out of #3398 as requested. Two armor stand fixes.

**A named armor stand loses its name when broken.** `break_and_drop_items` dropped a plain `ARMOR_STAND` item; there was a commented-out attempt in the code. Vanilla copies the custom name onto the dropped item (`ArmorStand.brokenByPlayer`). The name is now copied when the entity has one.

**With `mobGriefing=false` a player's projectile can't break a stand.** The check refused damage whenever the direct source wasn't a player, so an arrow (the arrow entity is the direct source) was blocked. Vanilla only refuses when the causing entity is a `Mob`: `!level.getGameRules().getBoolean(RULE_MOBGRIEFING) && damageSource.getEntity() instanceof Mob`. The check now looks at the causing entity, the same one the function already uses further down for `attacker`.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Armor stands now preserve their custom names when dropped as items.
  - Mob-griefing protection now correctly blocks damage caused by mobs while allowing damage from other non-player sources where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->