### PR TITLE
fix(world): drop blocks that lose support after a creative break

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -6356,7 +6356,12 @@ impl World {
 
         if new_state_id != block_state_id {
             if is_air(new_state_id) {
-                self.break_block(block_pos, None, flags | BlockFlags::NOTIFY_ALL);
+                // Like vanilla, suppressed drops don't carry over to blocks that lose support.
+                self.break_block(
+                    block_pos,
+                    None,
+                    flags.difference(BlockFlags::SKIP_DROPS) | BlockFlags::NOTIFY_ALL,
+                );
             } else {
                 self.set_block_state(block_pos, new_state_id, flags);
             }


### PR DESCRIPTION
Split out of #3399 as requested. Fixes #3120.

Breaking a block in creative passes `SKIP_DROPS`, and `replace_with_state_for_neighbor_update` forwarded those same flags when a torch, lever or button lost its support. Those blocks then vanished instead of dropping. Vanilla clears `UPDATE_SUPPRESS_DROPS` before neighbour shape updates: `Level.setBlock` passes `flags & -34` to `updateNeighbourShapes`.

The flag is now removed there too.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blocks that lose support and break during neighbor updates now correctly drop their loot.
  - Drop-suppression settings from the original update no longer incorrectly prevent drops from unsupported blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->