### PR TITLE
fix(block): deal stalagmite damage when landing on pointed dripstone

### DIFF
--- a/crates/pumpkin/src/block/blocks/dripstone.rs
+++ b/crates/pumpkin/src/block/blocks/dripstone.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use crate::{
     block::{
-        BlockBehaviour, BrokenArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, OnPlaceArgs,
-        PathComputationType, PlacedArgs,
+        BlockBehaviour, BrokenArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
+        OnLandedUponArgs, OnPlaceArgs, PathComputationType, PlacedArgs,
     },
     entity::player::Player,
     world::World,
@@ -11,6 +11,7 @@ use crate::{
 use pumpkin_data::{
     Block, BlockDirection, BlockState, BlockStateId,
     block_properties::{PointedDripstoneLikeProperties, SpeleothemThickness, VerticalDirection},
+    damage::DamageType,
 };
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
@@ -20,6 +21,28 @@ use pumpkin_world::world::{BlockAccessor, BlockFlags};
 pub struct DripstoneBlock;
 
 impl BlockBehaviour for DripstoneBlock {
+    fn on_landed_upon(&self, args: OnLandedUponArgs<'_>) {
+        let Some(living) = args.entity.get_living_entity() else {
+            return;
+        };
+        let props = PointedDripstoneLikeProperties::from_state_id(
+            args.world.get_block_state_id(args.position),
+        );
+        // Like vanilla, landing on the tip of a stalagmite deals extra stalagmite damage.
+        if props.vertical_direction == VerticalDirection::Up
+            && props.thickness == SpeleothemThickness::Tip
+        {
+            living.handle_fall_damage_from(
+                args.entity,
+                args.fall_distance + 2.5,
+                2.0,
+                DamageType::STALAGMITE,
+            );
+        } else {
+            living.handle_fall_damage(args.entity, args.fall_distance, 1.0);
+        }
+    }
+
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
         can_place_at_pos(
             args.block_accessor,

--- a/crates/pumpkin/src/block/blocks/dripstone.rs
+++ b/crates/pumpkin/src/block/blocks/dripstone.rs
@@ -34,7 +34,7 @@ impl BlockBehaviour for DripstoneBlock {
         {
             living.handle_fall_damage_from(
                 args.entity,
-                args.fall_distance + 2.5,
+                args.fall_distance + 2.0,
                 2.0,
                 DamageType::STALAGMITE,
             );

--- a/crates/pumpkin/src/block/mod.rs
+++ b/crates/pumpkin/src/block/mod.rs
@@ -358,6 +358,7 @@ pub struct PlayerPlacedArgs<'a> {
 
 pub struct OnLandedUponArgs<'a> {
     pub world: &'a Arc<World>,
+    pub position: &'a BlockPos,
     pub fall_distance: f32,
     pub entity: &'a dyn EntityBase,
 }

--- a/crates/pumpkin/src/block/registry.rs
+++ b/crates/pumpkin/src/block/registry.rs
@@ -1168,6 +1168,7 @@ impl BlockRegistry {
         &self,
         block: &Block,
         world: &Arc<World>,
+        position: &BlockPos,
         fall_distance: f32,
         entity: &dyn EntityBase,
     ) {
@@ -1175,6 +1176,7 @@ impl BlockRegistry {
         if let Some(pumpkin_block) = pumpkin_block {
             pumpkin_block.on_landed_upon(OnLandedUponArgs {
                 world,
+                position,
                 fall_distance,
                 entity,
             });

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1707,11 +1707,13 @@ impl LivingEntity {
                 return;
             }
             let world = self.entity.world.load();
-            let block = world.get_block(&self.entity.get_pos_with_y_offset(0.2).0);
+            let landing_pos = self.entity.get_pos_with_y_offset(0.2).0;
+            let block = world.get_block(&landing_pos);
             let pumpkin_block = world.block_registry.get_pumpkin_block(block.id);
             if let Some(pumpkin_block) = pumpkin_block {
                 pumpkin_block.on_landed_upon(OnLandedUponArgs {
                     world: &world,
+                    position: &landing_pos,
                     fall_distance,
                     entity: caller,
                 });
@@ -1736,6 +1738,17 @@ impl LivingEntity {
         caller: &dyn EntityBase,
         fall_distance: f32,
         damage_per_distance: f32,
+    ) {
+        self.handle_fall_damage_from(caller, fall_distance, damage_per_distance, DamageType::FALL);
+    }
+
+    /// Like [`Self::handle_fall_damage`], but with the damage type to deal (e.g. stalagmites).
+    pub fn handle_fall_damage_from(
+        &self,
+        caller: &dyn EntityBase,
+        fall_distance: f32,
+        damage_per_distance: f32,
+        damage_type: DamageType,
     ) {
         let may_fly = caller.get_player().is_some_and(|player| {
             player
@@ -1763,7 +1776,7 @@ impl LivingEntity {
 
         let damage = (unsafe_fall_distance * damage_per_distance).floor();
         if damage > 0.0 {
-            let check_damage = self.damage(caller, damage, DamageType::FALL); // Fall
+            let check_damage = self.damage(caller, damage, damage_type);
             if check_damage {
                 self.entity
                     .play_sound(Self::get_fall_sound(fall_distance as i32));


### PR DESCRIPTION
Split out of #3399 as requested. Fixes #3377.

Landing on a stalagmite did no extra damage: pointed dripstone had no `on_landed_upon`, so it used the default fall damage. Vanilla's `PointedDripstoneBlock.fallOn` calls `causeFallDamage(fallDistance + 2.0, 2.0, STALAGMITE)` for an upward tip.

- `PointedDripstoneBlock::on_landed_upon` applies that for `vertical_direction=up`, and otherwise falls back to the default.
- `OnLandedUponArgs` carries the landing position, so the block knows which state was landed on.
- `LivingEntity::handle_fall_damage_from` takes a damage type; `handle_fall_damage` keeps using `FALL`.

Testing: `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean, `cargo test -p pumpkin` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Living entities landing on the tip of an upward-pointing stalagmite now receive the appropriate stalagmite damage.
  * Other landings on pointed dripstone continue to apply standard fall damage.
  * Fall damage is now calculated using the correct landing position, improving consistency for block-specific landing effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->