### PR TITLE
fix(entity): make sheep sync color in read_nbt

### DIFF
--- a/crates/pumpkin/src/entity/passive/sheep.rs
+++ b/crates/pumpkin/src/entity/passive/sheep.rs
@@ -142,7 +142,7 @@ impl Mob for SheepEntity {
             .unwrap_or(false);
         let color = nbt.get_byte("Color").unwrap_or(0) as u8;
         let byte = (color & 0x0F) | if sheared { 0x10 } else { 0 };
-        self.color_and_sheared.store(byte, Ordering::Relaxed);
+        self.set_packed_and_sync(byte);
     }
 
     fn get_mob_entity(&self) -> &MobEntity {


### PR DESCRIPTION
one of the fixes from #3409 

## Description
Makes sheep sync the color when entering the world

Before this patch, the sheep was always white when entering when it should be another color

## Testing
I entered and verified the sheep color was correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sheep wool color and sheared status now remain synchronized with clients after being loaded from saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->