### PR TITLE
fix(entity): make chicken sync variant in read_nbt

### DIFF
--- a/crates/pumpkin/src/entity/passive/chicken.rs
+++ b/crates/pumpkin/src/entity/passive/chicken.rs
@@ -80,6 +80,19 @@ impl ChickenEntity {
 
         mob_arc
     }
+
+    fn set_variant_and_sync(&self, variant: u8) {
+        let entity = self.get_entity();
+        self.variant.store(variant, Ordering::Relaxed);
+        entity.set_synced_data(
+            pumpkin_data::tracked_data::chicken::VARIANT,
+            VarInt(self.variant.load(Ordering::Relaxed) as i32),
+        );
+    }
+
+    fn get_variant(&self) -> u8 {
+        self.variant.load(Ordering::Relaxed)
+    }
 }
 
 impl AgeableMob for ChickenEntity {
@@ -109,7 +122,7 @@ impl Mob for ChickenEntity {
 
     fn mob_write_nbt(&self, nbt: &mut NbtCompound) {
         nbt.put_int("EggLayTime", self.egg_lay_time.load(Ordering::Relaxed));
-        let variant_str = match self.variant.load(Ordering::Relaxed) {
+        let variant_str = match self.get_variant() {
             0 => "minecraft:cold",
             2 => "minecraft:warm",
             _ => "minecraft:temperate",
@@ -121,15 +134,13 @@ impl Mob for ChickenEntity {
         self.egg_lay_time
             .store(nbt.get_int("EggLayTime").unwrap_or(6000), Ordering::Relaxed);
         if let Some(variant_str) = nbt.get_string("variant") {
-            let variant = match variant_str
-                .strip_prefix("minecraft:")
-                .unwrap_or(variant_str)
-            {
+            let variant = match variant_str.trim_start_matches("minecraft:") {
                 "cold" => 0,
                 "warm" => 2,
                 _ => 1,
             };
-            self.variant.store(variant, Ordering::Relaxed);
+
+            self.set_variant_and_sync(variant);
         }
     }
 
@@ -138,12 +149,12 @@ impl Mob for ChickenEntity {
     }
 
     fn mob_set_variant_name(&self, name: &str) {
-        let variant = match name.strip_prefix("minecraft:").unwrap_or(name) {
+        let variant = match name.trim_start_matches("minecraft:") {
             "cold" => 0,
             "warm" => 2,
             _ => 1,
         };
-        self.variant.store(variant, Ordering::Relaxed);
+        self.set_variant_and_sync(variant);
     }
 
     fn mob_init_data_tracker(&self) {

--- a/crates/pumpkin/src/entity/passive/chicken.rs
+++ b/crates/pumpkin/src/entity/passive/chicken.rs
@@ -134,7 +134,10 @@ impl Mob for ChickenEntity {
         self.egg_lay_time
             .store(nbt.get_int("EggLayTime").unwrap_or(6000), Ordering::Relaxed);
         if let Some(variant_str) = nbt.get_string("variant") {
-            let variant = match variant_str.trim_start_matches("minecraft:") {
+            let variant = match variant_str
+                .strip_prefix("minecraft:")
+                .unwrap_or(variant_str)
+            {
                 "cold" => 0,
                 "warm" => 2,
                 _ => 1,
@@ -149,7 +152,7 @@ impl Mob for ChickenEntity {
     }
 
     fn mob_set_variant_name(&self, name: &str) {
-        let variant = match name.trim_start_matches("minecraft:") {
+        let variant = match name.strip_prefix("minecraft:").unwrap_or(name) {
             "cold" => 0,
             "warm" => 2,
             _ => 1,


### PR DESCRIPTION
one of the fixes from #3409 

## Description
Makes chicken sync the variant when entering the world

## Testing
The chicken currently does not spawn as a different variant so i based the implementation on existing code that uses data tracking and based on the vanilla decompiled code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chicken appearance variants now remain synchronized correctly between the server and client.
  * Chicken variants are preserved consistently when loading saved data or changing appearance names.
  * Variant names with the standard namespace prefix are handled correctly, while repeated prefixes no longer produce unexpected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->