### PR TITLE
refactor(bedrock): derive enum packet codecs and fix protocol naming

### DIFF
--- a/crates/pumpkin-macros/src/lib.rs
+++ b/crates/pumpkin-macros/src/lib.rs
@@ -568,6 +568,10 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
 
+    if let syn::Data::Enum(data) = &input.data {
+        return derive_enum_write(&input, data).into();
+    }
+
     let fields = if let syn::Data::Struct(data) = &input.data {
         data.fields.iter().map(|f| {
             let ident = f.ident.as_ref().unwrap();
@@ -638,6 +642,10 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
 
+    if let syn::Data::Enum(data) = &input.data {
+        return derive_enum_read(&input, data).into();
+    }
+
     let fields = if let syn::Data::Struct(data) = &input.data {
         data.fields.iter().map(|f| {
             let ident = f.ident.as_ref().unwrap();
@@ -700,6 +708,10 @@ pub fn derive_deserialize_from_slice(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
 
+    if let syn::Data::Enum(data) = &input.data {
+        return derive_enum_read_slice(&input, data).into();
+    }
+
     let fields = if let syn::Data::Struct(data) = &input.data {
         data.fields.iter().map(|f| {
             let ident = f.ident.as_ref().unwrap();
@@ -738,6 +750,171 @@ pub fn derive_deserialize_from_slice(input: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// How a unit enum's discriminant is laid out on the wire.
+struct EnumRepr {
+    /// The integer type from `#[repr(..)]`.
+    ty: syn::Ident,
+    /// `Some(path)` when the discriminant is variable-length encoded.
+    varint: Option<proc_macro2::TokenStream>,
+    is_big_endian: bool,
+}
+
+impl EnumRepr {
+    fn read_expr(&self, reader: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+        let ty = &self.ty;
+        match (&self.varint, self.is_big_endian) {
+            (Some(codec), _) => quote! { #codec::read(#reader)?.0 },
+            (None, true) => quote! { <#ty as PacketRead>::read_be(#reader)? },
+            (None, false) => quote! { <#ty as PacketRead>::read(#reader)? },
+        }
+    }
+
+    fn read_slice_expr(&self) -> proc_macro2::TokenStream {
+        let ty = &self.ty;
+        match (&self.varint, self.is_big_endian) {
+            (Some(codec), _) => quote! { #codec::read_slice(buf)?.0 },
+            (None, true) => syn::Error::new(ty.span(), "Cannot read big-endian enums from a slice")
+                .to_compile_error(),
+            (None, false) => quote! { <#ty as PacketReadSlice>::read_slice(buf)? },
+        }
+    }
+
+    fn write_expr(&self) -> proc_macro2::TokenStream {
+        let ty = &self.ty;
+        match (&self.varint, self.is_big_endian) {
+            (Some(codec), _) => quote! { #codec(*self as #ty).write(writer) },
+            (None, true) => quote! { (*self as #ty).write_be(writer) },
+            (None, false) => quote! { (*self as #ty).write(writer) },
+        }
+    }
+}
+
+/// Reads the discriminant layout from `#[repr(..)]` plus an optional
+/// `#[serial(varint)]` / `#[serial(big_endian)]` on the enum itself.
+fn parse_enum_repr(input: &DeriveInput) -> EnumRepr {
+    let mut ty = None;
+    for attr in &input.attrs {
+        if attr.path().is_ident("repr")
+            && let Ok(ident) = attr.parse_args::<syn::Ident>()
+        {
+            ty = Some(ident);
+        }
+    }
+
+    let Some(ty) = ty else {
+        abort!(
+            input.ident,
+            "Serializable enums need an explicit `#[repr(..)]` integer type"
+        );
+    };
+
+    let (is_big_endian, _) = check_serial_attributes(&input.attrs);
+    let mut is_varint = false;
+    for attr in &input.attrs {
+        if attr.path().is_ident("serial") {
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("varint") {
+                    is_varint = true;
+                }
+                Ok(())
+            });
+        }
+    }
+
+    let varint = is_varint.then(|| match ty.to_string().as_str() {
+        "i32" => quote! { crate::codec::var_int::VarInt },
+        "u32" => quote! { crate::codec::var_uint::VarUInt },
+        "i64" => quote! { crate::codec::var_long::VarLong },
+        "u64" => quote! { crate::codec::var_ulong::VarULong },
+        other => abort!(ty, "No variable-length encoding exists for `{}`", other),
+    });
+
+    EnumRepr {
+        ty,
+        varint,
+        is_big_endian,
+    }
+}
+
+/// Collects the variants of a field-less enum, aborting on anything else.
+fn unit_enum_variants(data: &syn::DataEnum) -> Vec<&syn::Ident> {
+    data.variants
+        .iter()
+        .map(|variant| {
+            if !matches!(variant.fields, Fields::Unit) {
+                abort!(variant, "Only field-less enum variants are supported");
+            }
+            &variant.ident
+        })
+        .collect()
+}
+
+/// Emits `TryFrom<repr>` and `PacketRead` for a field-less enum.
+fn derive_enum_read(input: &DeriveInput, data: &syn::DataEnum) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let repr = parse_enum_repr(input);
+    let ty = &repr.ty;
+    let variants = unit_enum_variants(data);
+    let read = repr.read_expr(&quote! { reader });
+
+    quote! {
+        impl TryFrom<#ty> for #name {
+            type Error = std::io::Error;
+
+            fn try_from(value: #ty) -> Result<Self, Self::Error> {
+                #(
+                    if value == Self::#variants as #ty {
+                        return Ok(Self::#variants);
+                    }
+                )*
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(concat!("Invalid ", stringify!(#name), ": {}"), value),
+                ))
+            }
+        }
+
+        impl PacketRead for #name {
+            fn read<R: std::io::Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+                Self::try_from(#read)
+            }
+        }
+    }
+}
+
+/// Emits `PacketReadSlice` for a field-less enum. Pair it with `PacketRead`,
+/// which provides the `TryFrom` conversion this relies on.
+fn derive_enum_read_slice(input: &DeriveInput, data: &syn::DataEnum) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let repr = parse_enum_repr(input);
+    let _ = unit_enum_variants(data);
+    let read = repr.read_slice_expr();
+
+    quote! {
+        impl<'a> PacketReadSlice<'a> for #name {
+            fn read_slice(buf: &mut &'a [u8]) -> Result<Self, std::io::Error> {
+                Self::try_from(#read)
+            }
+        }
+    }
+}
+
+/// Emits `PacketWrite` for a field-less enum.
+fn derive_enum_write(input: &DeriveInput, data: &syn::DataEnum) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let repr = parse_enum_repr(input);
+    let _ = unit_enum_variants(data);
+    let write = repr.write_expr();
+
+    quote! {
+        impl PacketWrite for #name {
+            fn write<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+                #write
+            }
+        }
+    }
 }
 
 /// Checks a field's `#[serial(...)]` attributes.

--- a/crates/pumpkin-nbt/fuzz/Cargo.lock
+++ b/crates/pumpkin-nbt/fuzz/Cargo.lock
@@ -37,6 +37,9 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -110,9 +113,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -236,9 +239,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -267,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-codecs"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "serde_json",
  "tracing",
@@ -275,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-nbt"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "bytes",
  "cesu8",
@@ -458,9 +461,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/crates/pumpkin-protocol/fuzz/Cargo.lock
+++ b/crates/pumpkin-protocol/fuzz/Cargo.lock
@@ -32,19 +32,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "4f10dafd0c8d2e51ae9a748805777613ed0bbe17bf586b76c8311f45c020a32f"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -59,28 +50,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base16ct"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
-
-[[package]]
 name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "block-buffer"
@@ -89,15 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -111,6 +81,9 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -167,25 +140,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "58a6d0db8759036a783bc7c3f7a07f8cef3bf9470eb1db3bc86e8bcd1c5d0fe8"
 dependencies = [
  "compression-core",
  "flate2",
@@ -193,15 +160,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "cpubits"
@@ -224,7 +185,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "spin",
 ]
 
@@ -238,77 +199,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
-dependencies = [
- "cpubits",
- "ctutils",
- "getrandom 0.4.2",
- "hybrid-array",
- "num-traits",
- "rand_core",
- "serdect",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -326,30 +220,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "getrandom 0.4.2",
  "hybrid-array",
- "rand_core",
-]
-
-[[package]]
-name = "crypto-primes"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
-dependencies = [
- "crypto-bigint",
- "libm",
- "rand_core",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
- "subtle",
 ]
 
 [[package]]
@@ -367,77 +238,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common 0.1.6",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.1",
- "ctutils",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
-dependencies = [
- "der",
- "digest 0.11.2",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
- "zeroize",
-]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "crypto-common 0.2.1",
- "digest 0.11.2",
- "ff",
- "group",
- "hybrid-array",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -453,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -463,22 +270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ff"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,12 +277,13 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -501,82 +293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,17 +300,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -621,17 +326,6 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "group"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -662,39 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.2",
-]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
- "subtle",
  "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -722,15 +389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -782,12 +440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,29 +455,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "lz4-java-wrc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed1c11dbd317fa5d0508cbb5ce47696bb27771e3c9604428e0e98c7c3d76d0d"
-dependencies = [
- "lz4_flex",
- "twox-hash",
-]
-
-[[package]]
-name = "lz4_flex"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -842,9 +478,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -858,7 +494,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -888,20 +524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "p384"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "fiat-crypto",
- "primefield",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,21 +545,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -989,26 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.8.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,33 +603,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primefield"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
-dependencies = [
- "crypto-bigint",
- "crypto-common 0.2.1",
- "ff",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
-dependencies = [
- "elliptic-curve",
- "once_cell",
- "primefield",
- "serdect",
- "wnaf",
 ]
 
 [[package]]
@@ -1077,26 +637,15 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-codecs"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "serde_json",
  "tracing",
 ]
 
 [[package]]
-name = "pumpkin-config"
-version = "0.1.0-dev+26.2-26.40"
-dependencies = [
- "pumpkin-util",
- "serde",
- "toml",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "pumpkin-data"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "crc-fast",
  "phf",
@@ -1108,19 +657,18 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-macros"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "heck",
  "proc-macro-error2",
  "proc-macro2",
- "pumpkin-data",
  "quote",
  "syn 3.0.3",
 ]
 
 [[package]]
 name = "pumpkin-nbt"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "bytes",
  "cesu8",
@@ -1133,12 +681,14 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-protocol"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
  "aes",
  "async-compression",
+ "base64",
  "bitflags",
  "bytes",
+ "cesu8",
  "cfb8",
  "flate2",
  "hybrid-array",
@@ -1146,13 +696,11 @@ dependencies = [
  "pumpkin-macros",
  "pumpkin-nbt",
  "pumpkin-util",
- "pumpkin-world",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "uuid",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -1167,60 +715,20 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-util"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0+26.2-26.45"
 dependencies = [
- "base64",
  "bytes",
  "colored",
- "crypto-bigint",
  "dashmap",
- "ecdsa",
  "md5",
  "num-derive",
  "num-traits",
- "p384",
  "pumpkin-codecs",
  "pumpkin-nbt",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "thiserror",
- "ureq",
  "uuid",
-]
-
-[[package]]
-name = "pumpkin-world"
-version = "0.1.0-dev+26.2-26.40"
-dependencies = [
- "arc-swap",
- "bitflags",
- "bytes",
- "crossbeam",
- "dashmap",
- "flate2",
- "futures",
- "itertools",
- "lz4-java-wrc",
- "pumpkin-config",
- "pumpkin-data",
- "pumpkin-nbt",
- "pumpkin-util",
- "rand",
- "rayon",
- "rustc-hash",
- "ruzstd",
- "serde",
- "serde_json",
- "sha2",
- "slotmap",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -1262,26 +770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,119 +779,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
-dependencies = [
- "crypto-bigint",
- "hmac",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.10.0-rc.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
-dependencies = [
- "const-oid",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.11.2",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "zeroize",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
-name = "rustls"
-version = "0.23.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ruzstd"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
-dependencies = [
- "base16ct",
- "ctutils",
- "der",
- "hybrid-array",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "semver"
@@ -1455,36 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serdect"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.11.2",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,16 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "digest 0.11.2",
- "rand_core",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,21 +866,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "smallvec"
@@ -1550,7 +880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1558,28 +888,6 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-
-[[package]]
-name = "spki"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1637,7 +945,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1650,58 +958,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1735,16 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,50 +1009,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
-dependencies = [
- "base64",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1925,28 +1131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1956,76 +1144,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -2116,27 +1234,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wnaf"
-version = "0.14.0"
+name = "zlib-rs"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
-dependencies = [
- "ff",
- "group",
- "hybrid-array",
-]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/pumpkin-protocol/src/bedrock/client/common.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/common.rs
@@ -1,13 +1,8 @@
-use std::io::{Error, Write};
-
 use pumpkin_util::GameMode;
 
-use crate::{
-    codec::{var_int::VarInt, var_long::VarLong},
-    serial::PacketWrite,
-};
+use crate::{codec::var_long::VarLong, serial::PacketWrite};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(i32)]
 pub enum BuildPlatform {
     Unknown = -1,
@@ -27,14 +22,9 @@ pub enum BuildPlatform {
     Linux = 15,
 }
 
-impl PacketWrite for BuildPlatform {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as i32).write(writer)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(i32)]
+#[serial(varint)]
 pub enum GameType {
     Unknown = -1,
     Survival = 0,
@@ -43,12 +33,6 @@ pub enum GameType {
     Default = 5,
     Spectator = 6,
     //WorldDefault = 0,
-}
-
-impl PacketWrite for GameType {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        VarInt(*self as i32).write(writer)
-    }
 }
 
 impl From<GameMode> for GameType {
@@ -70,7 +54,7 @@ pub struct SerializedAbilitiesData {
     pub layers: Vec<SerializedAbilitiesDataSerializedLayer>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(i8)]
 pub enum PlayerPermissionLevel {
     Visitor = 0,
@@ -79,13 +63,7 @@ pub enum PlayerPermissionLevel {
     Custom = 3,
 }
 
-impl PacketWrite for PlayerPermissionLevel {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as i8).write(writer)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(u8)]
 pub enum CommandPermissionLevel {
     Any = 0,
@@ -108,12 +86,6 @@ impl ToString for CommandPermissionLevel {
             Self::Internal => "internal",
         }
         .into()
-    }
-}
-
-impl PacketWrite for CommandPermissionLevel {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as u8).write(writer)
     }
 }
 

--- a/crates/pumpkin-protocol/src/bedrock/client/play_status.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/play_status.rs
@@ -1,13 +1,12 @@
 // Last verified for v2169
 
-use std::io::{Error, Write};
-
 use pumpkin_macros::packet;
 
 use crate::serial::PacketWrite;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PacketWrite)]
 #[repr(i32)]
+#[serial(big_endian)]
 #[packet(2)]
 pub enum CPlayStatus {
     LoginSuccess = 0,
@@ -20,12 +19,6 @@ pub enum CPlayStatus {
     ServerFullSubClient = 7,
     EditorMismatchEditorToVanilla = 8,
     EditorMismatchVanillaToEditor = 9,
-}
-
-impl PacketWrite for CPlayStatus {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as i32).write_be(writer)
-    }
 }
 
 #[cfg(test)]

--- a/crates/pumpkin-protocol/src/bedrock/client/resource_pack_stack.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/resource_pack_stack.rs
@@ -4,7 +4,7 @@ use crate::{bedrock::client::start_game::Experiments, serial::PacketWrite};
 use pumpkin_macros::packet;
 
 #[derive(PacketWrite)]
-pub struct PackInstanceId {
+pub struct PackEntry {
     pub pack_id: String,
     pub version: String,
     pub sub_pack_name: String,
@@ -14,8 +14,8 @@ pub struct PackInstanceId {
 #[packet(7)]
 pub struct CResourcePackStackPacket {
     pub texture_pack_required: bool,
-    pub texture_pack_list: Vec<PackInstanceId>,
+    pub texture_pack_list: Vec<PackEntry>,
     pub base_game_version: String,
     pub experiments: Experiments,
-    pub include_editor_packs: bool,
+    pub use_vanilla_editor_packs: bool,
 }

--- a/crates/pumpkin-protocol/src/bedrock/client/set_spawn_position.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/set_spawn_position.rs
@@ -1,7 +1,5 @@
 // Last verified for v2169
 
-use std::io::{Error, Write};
-
 use pumpkin_macros::packet;
 use pumpkin_util::math::position::BlockPos;
 
@@ -16,15 +14,10 @@ pub struct CSetSpawnPosition {
     pub spawn_block_pos: BlockPos,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(i32)]
+#[serial(varint)]
 pub enum SpawnPositionType {
     PlayerRespawn,
     WorldRespawn,
-}
-
-impl PacketWrite for SpawnPositionType {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        VarInt(*self as i32).write(writer)
-    }
 }

--- a/crates/pumpkin-protocol/src/bedrock/client/set_title.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/set_title.rs
@@ -1,7 +1,5 @@
 // Last verified for v2169
 
-use std::io::{Error, Write};
-
 use crate::{codec::var_int::VarInt, serial::PacketWrite};
 use pumpkin_macros::packet;
 
@@ -18,8 +16,9 @@ pub struct CSetTitle {
     pub filtered_title_message: String,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketWrite)]
 #[repr(i32)]
+#[serial(varint)]
 pub enum TitleType {
     Clear,
     Reset,
@@ -30,12 +29,6 @@ pub enum TitleType {
     TitleTextObject,
     SubtitleTextObject,
     ActionbarTextObject,
-}
-
-impl PacketWrite for TitleType {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        VarInt(*self as i32).write(writer)
-    }
 }
 
 impl CSetTitle {

--- a/crates/pumpkin-protocol/src/bedrock/client/start_game.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/start_game.rs
@@ -188,19 +188,15 @@ pub struct ExperimentToggle {
     pub enabled: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PacketWrite)]
+#[repr(i32)]
+#[serial(varint)]
 pub enum GamePublishSetting {
     NoMultiPlay = 0,
     InviteOnly = 1,
     FriendsOnly = 2,
     FriendsOfFriends = 3,
     Public = 4,
-}
-
-impl PacketWrite for GamePublishSetting {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        VarInt(*self as i32).write(writer)
-    }
 }
 
 #[derive(PacketWrite)]

--- a/crates/pumpkin-protocol/src/bedrock/mod.rs
+++ b/crates/pumpkin-protocol/src/bedrock/mod.rs
@@ -13,5 +13,5 @@ pub enum SubClient {
     Main = 0,
     SubClient0 = 1,
     SubClient1 = 2,
-    SubClietn2 = 3,
+    SubClient2 = 3,
 }

--- a/crates/pumpkin-protocol/src/bedrock/server/animate.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/animate.rs
@@ -1,9 +1,6 @@
 // Last verified for v2169
 
-use std::{
-    io::{Error, Read, Write},
-    str::FromStr,
-};
+use std::{io::Error, str::FromStr};
 
 use pumpkin_macros::packet;
 
@@ -13,7 +10,7 @@ use crate::{
     serial::{PacketRead, PacketWrite},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PacketRead, PacketWrite)]
 #[repr(u8)]
 pub enum AnimateAction {
     NoAction = 0,
@@ -21,26 +18,6 @@ pub enum AnimateAction {
     WakeUp = 3,
     CriticalHit = 4,
     MagicCriticalHit = 5,
-}
-
-impl PacketRead for AnimateAction {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        let action = u8::read(reader)?;
-        match action {
-            0 => Ok(Self::NoAction),
-            1 => Ok(Self::SwingArm),
-            3 => Ok(Self::WakeUp),
-            4 => Ok(Self::CriticalHit),
-            5 => Ok(Self::MagicCriticalHit),
-            _ => Err(Error::other(format!("Invalid animate action ID: {action}"))),
-        }
-    }
-}
-
-impl PacketWrite for AnimateAction {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as u8).write(writer)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/pumpkin-protocol/src/bedrock/server/interact.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/interact.rs
@@ -1,7 +1,5 @@
 // Last verified for v2169
 
-use std::io::{Error, Read};
-
 use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 
@@ -15,7 +13,7 @@ pub struct SInteract {
     pub position: Option<Vector3<f32>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PacketRead)]
 #[repr(u8)]
 pub enum Action {
     Invalid = 0,
@@ -23,17 +21,4 @@ pub enum Action {
     InteractUpdate = 4,
     NpcOpen = 5,
     OpenInventory = 6,
-}
-
-impl PacketRead for Action {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        match u8::read(reader)? {
-            0 => Ok(Self::Invalid),
-            3 => Ok(Self::StopRiding),
-            4 => Ok(Self::InteractUpdate),
-            5 => Ok(Self::NpcOpen),
-            6 => Ok(Self::OpenInventory),
-            _ => Err(Error::other("")),
-        }
-    }
 }

--- a/crates/pumpkin-protocol/src/bedrock/server/loading_screen.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/loading_screen.rs
@@ -1,10 +1,8 @@
 // Last verified for v2169
 
-use std::io::{Error, Read};
-
 use pumpkin_macros::packet;
 
-use crate::{codec::var_int::VarInt, serial::PacketRead};
+use crate::serial::PacketRead;
 
 #[derive(PacketRead)]
 #[packet(312)]
@@ -13,23 +11,12 @@ pub struct SLoadingScreen {
     _loading_screen_id: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PacketRead)]
 #[repr(i32)]
+#[serial(varint)]
 pub enum LoadingScreenPacketType {
     StartLoadingScreen = 0,
     EndLoadingScreen = 1,
-}
-
-impl PacketRead for LoadingScreenPacketType {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        match VarInt::read(reader)?.0 {
-            0 => Ok(Self::StartLoadingScreen),
-            1 => Ok(Self::EndLoadingScreen),
-            val => Err(Error::other(format!(
-                "Invalid LoadingScreenPacketType: {val}"
-            ))),
-        }
-    }
 }
 
 impl SLoadingScreen {

--- a/crates/pumpkin-protocol/src/bedrock/server/player_action.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/player_action.rs
@@ -1,7 +1,5 @@
 // Last verified for v2169
 
-use std::io::{Error, Read};
-
 use pumpkin_macros::packet;
 use pumpkin_util::math::position::BlockPos;
 
@@ -20,8 +18,9 @@ pub struct SPlayerAction {
     pub face: VarInt,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PacketRead)]
 #[repr(i32)]
+#[serial(varint)]
 pub enum PlayerActionType {
     Unknown = -1,
     StartDestroyBlock,
@@ -65,63 +64,4 @@ pub enum PlayerActionType {
     StartUsingItem,
     InternalUpdate,
     Count,
-}
-
-impl TryFrom<i32> for PlayerActionType {
-    type Error = String;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        match value {
-            -1 => Ok(Self::Unknown),
-            0 => Ok(Self::StartDestroyBlock),
-            1 => Ok(Self::AbortDestroyBlock),
-            2 => Ok(Self::StopDestroyBlock),
-            3 => Ok(Self::GetUpdatedBlock),
-            4 => Ok(Self::DropItem),
-            5 => Ok(Self::StartSleeping),
-            6 => Ok(Self::StopSleeping),
-            7 => Ok(Self::Respawn),
-            8 => Ok(Self::StartJump),
-            9 => Ok(Self::StartSprinting),
-            10 => Ok(Self::StopSprinting),
-            11 => Ok(Self::StartSneaking),
-            12 => Ok(Self::StopSneaking),
-            13 => Ok(Self::CreativeDestroyBlock),
-            14 => Ok(Self::ChangeDimensionAck),
-            15 => Ok(Self::StartGliding),
-            16 => Ok(Self::StopGliding),
-            17 => Ok(Self::DenyDestroyBlock),
-            18 => Ok(Self::CrackBlock),
-            19 => Ok(Self::ChangeSkin),
-            20 => Ok(Self::UpdatedEnchantingSeed),
-            21 => Ok(Self::StartSwimming),
-            22 => Ok(Self::StopSwimming),
-            23 => Ok(Self::StartSpinAttack),
-            24 => Ok(Self::StopSpinAttack),
-            25 => Ok(Self::InteractWithBlock),
-            26 => Ok(Self::PredictDestroyBlock),
-            27 => Ok(Self::ContinueDestroyBlock),
-            28 => Ok(Self::StartItemUseOn),
-            29 => Ok(Self::StopItemUseOn),
-            30 => Ok(Self::HandledTeleport),
-            31 => Ok(Self::MissedSwing),
-            32 => Ok(Self::StartCrawling),
-            33 => Ok(Self::StopCrawling),
-            34 => Ok(Self::StartFlying),
-            35 => Ok(Self::StopFlying),
-            36 => Ok(Self::ClientAckServerData),
-            37 => Ok(Self::StartUsingItem),
-            38 => Ok(Self::InternalUpdate),
-            39 => Ok(Self::Count),
-            _ => Err(format!("Invalid action ID: {value}")),
-        }
-    }
-}
-
-impl PacketRead for PlayerActionType {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        let action = VarInt::read(reader)?;
-
-        Self::try_from(action.0).map_err(Error::other)
-    }
 }

--- a/crates/pumpkin-protocol/src/bedrock/server/respawn.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/respawn.rs
@@ -1,7 +1,5 @@
 // Last verified for v2169
 
-use std::io::{Error, ErrorKind, Read, Write};
-
 use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 
@@ -18,32 +16,12 @@ pub struct SRespawn {
     pub player_runtime_id: VarULong,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PacketRead, PacketWrite)]
 #[repr(u8)]
 pub enum RespawnState {
     SearchingForSpawn,
     ReadyToSpawn,
     ClientReadyToSpawn,
-}
-
-impl PacketRead for RespawnState {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        match u8::read(reader)? {
-            0 => Ok(Self::SearchingForSpawn),
-            1 => Ok(Self::ReadyToSpawn),
-            2 => Ok(Self::ClientReadyToSpawn),
-            state => Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("invalid Bedrock respawn state {state}"),
-            )),
-        }
-    }
-}
-
-impl PacketWrite for RespawnState {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as u8).write(writer)
-    }
 }
 
 #[cfg(test)]

--- a/crates/pumpkin-protocol/src/bedrock/server/text.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/text.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use pumpkin_macros::packet;
 use std::borrow::Cow;
-use std::io::{Error, ErrorKind, Read, Write};
+use std::io::{Error, Read, Write};
 
 #[derive(Debug)]
 #[packet(9)]
@@ -262,7 +262,7 @@ impl PacketWrite for SText<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PacketRead, PacketReadSlice, PacketWrite)]
 #[repr(u8)]
 pub enum TextPacketType {
     Raw = 0,
@@ -277,50 +277,4 @@ pub enum TextPacketType {
     JsonWhisper = 9,
     Json = 10,
     JsonAnnouncement = 11,
-}
-
-impl PacketWrite for TextPacketType {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        (*self as u8).write(writer)
-    }
-}
-
-impl PacketRead for TextPacketType {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        match u8::read(reader)? {
-            0 => Ok(Self::Raw),
-            1 => Ok(Self::Chat),
-            2 => Ok(Self::Translation),
-            3 => Ok(Self::Popup),
-            4 => Ok(Self::JukeboxPopup),
-            5 => Ok(Self::Tip),
-            6 => Ok(Self::System),
-            7 => Ok(Self::Whisper),
-            8 => Ok(Self::Announcement),
-            9 => Ok(Self::JsonWhisper),
-            10 => Ok(Self::Json),
-            11 => Ok(Self::JsonAnnouncement),
-            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown Text Type")),
-        }
-    }
-}
-
-impl<'a> PacketReadSlice<'a> for TextPacketType {
-    fn read_slice(buf: &mut &'a [u8]) -> Result<Self, Error> {
-        match u8::read_slice(buf)? {
-            0 => Ok(Self::Raw),
-            1 => Ok(Self::Chat),
-            2 => Ok(Self::Translation),
-            3 => Ok(Self::Popup),
-            4 => Ok(Self::JukeboxPopup),
-            5 => Ok(Self::Tip),
-            6 => Ok(Self::System),
-            7 => Ok(Self::Whisper),
-            8 => Ok(Self::Announcement),
-            9 => Ok(Self::JsonWhisper),
-            10 => Ok(Self::Json),
-            11 => Ok(Self::JsonAnnouncement),
-            _ => Err(Error::new(ErrorKind::InvalidData, "Unknown Text Type")),
-        }
-    }
 }

--- a/crates/pumpkin-protocol/src/bedrock/status.rs
+++ b/crates/pumpkin-protocol/src/bedrock/status.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn formats_vanilla_26_45_advertisement() {
+    fn formats_vanilla_advertisement() {
         let info = ServerInfo {
             motd: "Pumpkin",
             protocol: 2169,

--- a/crates/pumpkin-util/src/version.rs
+++ b/crates/pumpkin-util/src/version.rs
@@ -74,7 +74,7 @@ pub enum JavaMinecraftVersion {
     V_1_21_7,
     V_1_21_9,
     V_1_21_11,
-    //  26.1: Tiny Takeover
+    /// 26.1: Tiny Takeover
     V_26_1,
     V_26_2,
     /// Fallback for unrecognized protocol versions.
@@ -287,8 +287,6 @@ impl std::fmt::Display for JavaMinecraftVersion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 #[allow(non_camel_case_types)]
 pub enum BedrockMinecraftVersion {
-    /// 1.21: Tricky Trials.
-    V_1_21,
     /// 1.26.45
     V_1_26_45,
     /// Fallback for unrecognized protocol versions.
@@ -302,7 +300,6 @@ impl BedrockMinecraftVersion {
     #[must_use]
     pub const fn protocol_version(&self) -> i32 {
         match self {
-            Self::V_1_21 => 671,
             Self::V_1_26_45 => 2169,
             Self::Unknown => -1,
         }
@@ -314,7 +311,6 @@ impl BedrockMinecraftVersion {
     #[must_use]
     pub const fn from_protocol(protocol: u32) -> Self {
         match protocol {
-            671 => Self::V_1_21,
             2169 => Self::V_1_26_45,
             _ => Self::Unknown,
         }
@@ -324,23 +320,8 @@ impl BedrockMinecraftVersion {
 impl std::fmt::Display for BedrockMinecraftVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::V_1_21 => write!(f, "1.21"),
             Self::V_1_26_45 => write!(f, "1.26.45"),
             Self::Unknown => write!(f, "unknown"),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::BedrockMinecraftVersion;
-
-    #[test]
-    fn resolves_bedrock_26_45_protocol() {
-        let version = BedrockMinecraftVersion::from_protocol(2169);
-
-        assert_eq!(version, BedrockMinecraftVersion::V_1_26_45);
-        assert_eq!(version.protocol_version(), 2169);
-        assert_eq!(version.to_string(), "1.26.45");
     }
 }

--- a/crates/pumpkin/src/net/bedrock/login/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/login/mod.rs
@@ -15,7 +15,7 @@ use pumpkin_protocol::bedrock::{
     server::{login::SLogin, request_network_settings::SRequestNetworkSettings},
 };
 use pumpkin_protocol::bedrock::{
-    client::{resource_pack_stack::PackInstanceId, resource_packs_info::PackInfoData},
+    client::{resource_pack_stack::PackEntry, resource_packs_info::PackInfoData},
     server::{login::ClientData, resource_pack_client_response::SResourcePackClientResponse},
 };
 use pumpkin_util::version::BedrockMinecraftVersion;

--- a/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
+++ b/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
@@ -59,21 +59,3 @@ impl BedrockClient {
         true
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn accepts_only_the_current_bedrock_protocol() {
-        assert!(matches!(
-            incompatible_protocol_status(2168),
-            Some(CPlayStatus::OutdatedClient)
-        ));
-        assert!(incompatible_protocol_status(2169).is_none());
-        assert!(matches!(
-            incompatible_protocol_status(2170),
-            Some(CPlayStatus::OutdatedServer)
-        ));
-    }
-}

--- a/crates/pumpkin/src/net/bedrock/login/resource_pack_response.rs
+++ b/crates/pumpkin/src/net/bedrock/login/resource_pack_response.rs
@@ -48,7 +48,7 @@ impl BedrockClient {
                         toggles: Vec::new(),
                         experiments_ever_toggled: false,
                     },
-                    include_editor_packs: false,
+                    use_vanilla_editor_packs: false,
                 })
                 .await;
             }

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -32,7 +32,8 @@ use pumpkin_protocol::{
             client_cache_status::SClientCacheStatus, command_request::SCommandRequest,
             container_close::SContainerClose, emote::SEmote, emote_list::SEmoteList,
             interact::SInteract, inventory_transaction::SInventoryTransaction,
-            loading_screen::SLoadingScreen, login::SLogin, mob_equipment::SMobEquipment,
+            item_stack_request::SItemStackRequest, loading_screen::SLoadingScreen, login::SLogin,
+            mob_equipment::SMobEquipment, modal_form_response::SModalFormResponse,
             packet_violation_warning::SPacketViolationWarning, player_action::SPlayerAction,
             player_auth_input::SPlayerAuthInput, request_ability::SRequestAbility,
             request_chunk_radius::SRequestChunkRadius,
@@ -751,7 +752,9 @@ impl BedrockClient {
                 let client = self.clone();
                 let server_c = server.clone();
                 server.spawn_task(async move {
-                    client.handle_resource_pack_response(packet, &server_c).await;
+                    client
+                        .handle_resource_pack_response(packet, &server_c)
+                        .await;
                 });
             }
             SPlayerAuthInput::PACKET_ID => {
@@ -766,8 +769,8 @@ impl BedrockClient {
                 let packet = SInventoryTransaction::read(reader)?;
                 self.handle_inventory_action(player, packet);
             }
-            pumpkin_protocol::bedrock::server::item_stack_request::SItemStackRequest::PACKET_ID => {
-                let packet = pumpkin_protocol::bedrock::server::item_stack_request::SItemStackRequest::read(reader)?;
+            SItemStackRequest::PACKET_ID => {
+                let packet = SItemStackRequest::read(reader)?;
                 self.handle_item_stack_request(player, packet);
             }
             SInteract::PACKET_ID => {
@@ -826,10 +829,8 @@ impl BedrockClient {
             SEmoteList::PACKET_ID => {
                 self.handle_emote_list(player, &SEmoteList::read(reader)?);
             }
-            pumpkin_protocol::bedrock::server::modal_form_response::SModalFormResponse::PACKET_ID => {
-                let form_resp = pumpkin_protocol::bedrock::server::modal_form_response::SModalFormResponse::read(
-                    reader,
-                )?;
+            SModalFormResponse::PACKET_ID => {
+                let form_resp = SModalFormResponse::read(reader)?;
                 self.handle_modal_form_response(player, server, form_resp);
             }
             SLoadingScreen::PACKET_ID => {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -173,10 +173,8 @@ const fn to_wasm_bedrock_version(
     version: BedrockMinecraftVersion,
 ) -> pumpkin::plugin::player::BedrockMinecraftVersion {
     match version {
-        BedrockMinecraftVersion::V_1_21 => pumpkin::plugin::player::BedrockMinecraftVersion::V121,
         BedrockMinecraftVersion::V_1_26_45 => {
-            // The v0.1 plugin ABI predates 26.45; do not misreport it as 26.30.
-            pumpkin::plugin::player::BedrockMinecraftVersion::Unknown
+            pumpkin::plugin::player::BedrockMinecraftVersion::V12645
         }
         BedrockMinecraftVersion::Unknown => {
             pumpkin::plugin::player::BedrockMinecraftVersion::Unknown


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
Unit enums can now derive PacketRead/PacketWrite/PacketReadSlice, with the
wire layout taken from #[repr] plus an optional #[serial(varint)] or
#[serial(big_endian)]. That replaces fourteen hand-written impls across the
Bedrock packets, including three copies of the same TextPacketType table and
a 45-arm PlayerActionType match.

Alongside that: PackInstanceId is now PackEntry, include_editor_packs is
use_vanilla_editor_packs, the SubClietn2 typo is fixed, and the dead Bedrock
1.21 version entry is gone now that the v0.1 plugin ABI reports 1.26.45
properly.

## Testing
All passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Bedrock protocol compatibility for enum values using VarInt and big-endian encodings.
  - Bedrock version 1.26.45 is now correctly recognized by the plugin interface.

- **Bug Fixes**
  - Added validation and clearer errors for invalid or unsupported enum values.
  - Corrected the `SubClient2` protocol variant name.
  - Updated resource-pack stack handling and editor-pack settings.

- **Breaking Changes**
  - Removed support for the obsolete Bedrock 1.21 version identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->